### PR TITLE
Look for authorName in author.profile.name

### DIFF
--- a/collections/post.coffee
+++ b/collections/post.coffee
@@ -60,7 +60,10 @@ class @Post extends Minimongoid
     author = @author()
 
     if author
-      if author.profile and author.profile.firstName and author.profile.lastName
+      if author.profile.name
+        return author.profile.name
+        
+      else if author.profile and author.profile.firstName and author.profile.lastName
         return "#{author.profile.firstName} #{author.profile.lastName}"
 
       else if author.profile and author.profile.twitter


### PR DESCRIPTION
I needed this to avoid showing "Mystery blogger" on all of my blog posts. I'm using accounts-google, and it seems to set names at author.profile.name.
