### PR TITLE
Bugfix: replaced usage of publisedAt with createdAt

### DIFF
--- a/client/views/admin/admin.html
+++ b/client/views/admin/admin.html
@@ -43,7 +43,7 @@
 
 <template name="blogAdminPublishedColumn">
   {{#if published}}
-    {{blogFormatDate publishedAt}}
+    {{blogFormatDate createdAt}}
   {{else}}
     <i class="fa fa-ban"></i>
   {{/if}}

--- a/client/views/blog/blog.html
+++ b/client/views/blog/blog.html
@@ -18,7 +18,7 @@
         <a href="{{pathFor 'blogShow'}}">{{title}}</a>
       </h2>
       <div class="post-meta">
-        By {{authorName}} on {{blogFormatDate publishedAt}}
+        By {{authorName}} on date: {{blogFormatDate createdAt}}
         {{> blogTags }}
       </div>
       <div class="the-content">

--- a/client/views/blog/show.html
+++ b/client/views/blog/show.html
@@ -14,7 +14,7 @@
   <article class="post">
     <h2>{{title}}</h2>
     <div class="post-meta">
-      By {{authorName}} on {{blogFormatDate publishedAt}}
+      By {{authorName}} on {{blogFormatDate createdAt}}
       {{> blogTags }}
     </div>
     <div id="commentable-area" class="the-content">


### PR DESCRIPTION
'createdAt' is the one used in blog_posts in mongoDB.
