### PR TITLE
Fix issue of session not being defined on /blog when using fast render

### DIFF
--- a/router.coffee
+++ b/router.coffee
@@ -32,10 +32,12 @@ Router.map ->
       if not Session.get('postLimit') and Blog.settings.pageSize
         Session.set 'postLimit', Blog.settings.pageSize
 
-    waitOn: -> [
-      Meteor.subscribe 'posts', Session.get('postLimit')
-      Meteor.subscribe 'authors'
-    ]
+    waitOn: ->
+      if (typeof Session isnt 'undefined')
+        [
+          Meteor.subscribe 'posts', Session.get('postLimit')
+          Meteor.subscribe 'authors'
+        ]
 
     fastRender: true
 


### PR DESCRIPTION
Server was throwing error any time /blog was hit that Session wasn't defined if using fast render.

Would close #85.
