### PR TITLE
redirect to 404 template when no post is found for slug

### DIFF
--- a/router.coffee
+++ b/router.coffee
@@ -98,6 +98,9 @@ Router.map ->
           Template[tpl].rendered = pkgFunc
 
     action: ->
+      if @ready() and not @data()
+        Router.go 'blogNotFound', slug: @params.slug
+        return
       @render() if @ready()
 
     waitOn: -> [
@@ -164,3 +167,11 @@ Router.map ->
 
     data: ->
       true
+
+  #
+  # Post Not Found
+  #
+
+  @route 'blogNotFound',
+    path: '/blog/notfound/:slug'
+    template: 'blogNotFound'


### PR DESCRIPTION
Currently tries to render into normal post template.  When this happens it throws exceptions and displays template fragments/bad data.
