### PR TITLE
Fix CoffeeScript parenthesis typo in 'authors' publication

### DIFF
--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -32,7 +32,7 @@ Meteor.publish 'taggedPosts', (tag) ->
     sort: publishedAt: -1
 
 Meteor.publish 'authors', ->
-  ids = _.uniq(_.pluck(Post.all(fields: userId: 1, 'userId')))
+  ids = _.uniq(_.pluck(Post.all(fields: userId: 1), 'userId'))
 
   Author.find
     id: $in: ids


### PR DESCRIPTION
This typo was breaking the publication for me, and resulting in sporadic "Mystery blogger" authors due to the client not having the relevant users.
