### PR TITLE
Add ability to define custom blog admin route.

### DIFF
--- a/client/boot.coffee
+++ b/client/boot.coffee
@@ -1,45 +1,4 @@
 ################################################################################
-# Client-side Config
-#
-
-
-Blog =
-  settings:
-    title: ''
-    blogIndexTemplate: null
-    blogShowTemplate: null
-    blogNotFoundTemplate: null
-    blogAdminTemplate: null
-    blogAdminEditTemplate: null
-    pageSize: 20
-    excerptFunction: null
-    syntaxHighlighting: false
-    syntaxHighlightingTheme: 'github'
-    comments:
-      allowAnonymous: false
-      useSideComments: false
-      defaultImg: '/packages/blog/public/default-user.png'
-      userImg: 'avatar'
-      disqusShortname: null
-
-  config: (appConfig) ->
-    # No deep extend in underscore :-(
-    if appConfig.comments
-      @settings.comments = _.extend(@settings.comments, appConfig.comments)
-      delete appConfig.comments
-    @settings = _.extend(@settings, appConfig)
-
-    if @settings.syntaxHighlightingTheme
-      $('<link>',
-        href: '//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/' + @settings.syntaxHighlightingTheme + '.min.css'
-        rel: 'stylesheet'
-      ).appendTo 'head'
-
-
-@Blog = Blog
-
-
-################################################################################
 # Bootstrap Code
 #
 

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,51 @@
+################################################################################
+# Config
+#
+
+
+Blog =
+  settings:
+    title: ''
+    blogIndexTemplate: null
+    blogShowTemplate: null
+    blogNotFoundTemplate: null
+    blogAdminTemplate: null
+    blogAdminEditTemplate: null
+    blogAdminRoute: "/blog/admin"
+    pageSize: 20
+    excerptFunction: null
+    syntaxHighlighting: false
+    syntaxHighlightingTheme: 'github'
+    comments:
+      allowAnonymous: false
+      useSideComments: false
+      defaultImg: '/packages/blog/public/default-user.png'
+      userImg: 'avatar'
+      disqusShortname: null
+
+  config: (appConfig) ->
+    for func in @configs
+      func( appConfig )
+
+  configs: [ 
+    (appConfig) ->
+      # No deep extend in underscore :-(
+      if appConfig.comments
+        @settings.comments = _.extend(@settings.comments, appConfig.comments)
+        delete appConfig.comments
+      @settings = _.extend(@settings, appConfig)
+
+      if @settings.syntaxHighlightingTheme
+        $('<link>',
+          href: '//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/' + @settings.syntaxHighlightingTheme + '.min.css'
+          rel: 'stylesheet'
+        ).appendTo 'head'
+  ]
+  
+  extend: (extended) ->
+    extended.settings = _.extend(extended.settings, @settings)
+    extended.settings.comments = _.extend(extended.settings.rss, @settings.comments)
+    extended.configs = extended.configs.concat( @configs )
+    return extended
+
+@Blog = if @Blog then @Blog.extend( Blog ) else Blog

--- a/package.js
+++ b/package.js
@@ -10,6 +10,8 @@ Package.onUse(function(api) {
 
   var both = ['client', 'server'];
 
+  api.addFiles( 
+     )
   /**
    * Packages for client
    */
@@ -19,7 +21,6 @@ Package.onUse(function(api) {
     'templating',
     'ui',
     'less',
-    'underscore',
     'aslagle:reactive-table@0.4.0',
     'joshowens:shareit@0.1.0',
     'gfk:notifications@1.0.9'
@@ -95,6 +96,7 @@ Package.onUse(function(api) {
    */
 
   api.use([
+    'underscore',
     'coffeescript',
     'deps',
     'iron:router@0.9.1',
@@ -117,7 +119,8 @@ Package.onUse(function(api) {
     'collections/post.coffee',
     'collections/comment.coffee',
     'collections/tag.coffee',
-    'collections/files.coffee'
+    'collections/files.coffee',
+    'lib/config.coffee'
   ], both);
 });
 

--- a/router.coffee
+++ b/router.coffee
@@ -12,165 +12,168 @@ if Meteor.isClient
 
     Router.hooks.dataNotFound.call @, pause
 
-Router.map ->
 
-  #
-  # RSS Feed
-  #
+Meteor.startup ->
+  Router.map ->
 
-  if Meteor.isServer
-    @route 'rss',
-      where: 'server'
-      path: '/rss/posts'
+    #
+    # RSS Feed
+    #
+
+    if Meteor.isServer
+      @route 'rss',
+        where: 'server'
+        path: '/rss/posts'
+        action: ->
+          @response.write Meteor.call 'serveRSS'
+          @response.end()
+
+    #
+    # Blog Index
+    #
+
+    @route 'blogIndex',
+      path: '/blog'
+      template: 'dynamic'
+
+      onRun: ->
+        if not Session.get('postLimit') and Blog.settings.pageSize
+          Session.set 'postLimit', Blog.settings.pageSize
+
+      waitOn: ->
+        if (typeof Session isnt 'undefined')
+          [
+            subs.subscribe 'posts', Session.get('postLimit')
+            subs.subscribe 'authors'
+          ]
+
+      fastRender: true
+
+      data: ->
+        posts: Post.where {},
+          sort: publishedAt: -1
+
+    #
+    # Blog Tag
+    #
+
+    @route 'blogTagged',
+      path: '/blog/tag/:tag'
+      template: 'dynamic'
+
+      waitOn: -> [
+        subs.subscribe 'taggedPosts', @params.tag
+        subs.subscribe 'authors'
+      ]
+
+      fastRender: true
+
+      data: ->
+        posts: Post.where
+          tags: @params.tag
+        ,
+          sort: publishedAt: -1
+
+
+    #
+    # Blog Admin Index
+    #
+
+    @route 'blogAdmin',
+      path: Blog.settings.blogAdminRoute
+      template: 'dynamic'
+
+      onBeforeAction: (pause) ->
+        if Meteor.loggingIn()
+          return pause()
+
+        Deps.autorun () ->
+          Router.go 'blogIndex' if not Meteor.userId()
+
+        Meteor.call 'isBlogAuthorized', (err, authorized) =>
+          if not authorized
+            return @redirect('/blog')
+
+      waitOn: ->
+        [ Meteor.subscribe 'postForAdmin'
+          Meteor.subscribe 'authors' ]
+
+      data: ->
+        true
+
+    #
+    # New/Edit Blog
+    #
+
+    @route 'blogAdminEdit',
+      path: Blog.settings.blogAdminRoute + '/edit/:id'
+      template: 'dynamic'
+
+      onBeforeAction: (pause) ->
+        if Meteor.loggingIn()
+          return pause()
+
+        Deps.autorun () ->
+          Router.go 'blogIndex' if not Meteor.userId()
+          
+        Meteor.call 'isBlogAuthorized', @params.id, (err, authorized) =>
+          if not authorized
+            return @redirect('/blog')
+
       action: ->
-        @response.write Meteor.call 'serveRSS'
-        @response.end()
+        @render() if @ready()
 
-  #
-  # Blog Index
-  #
+      onRun: ->
+        Session.set 'postId', @params.id
 
-  @route 'blogIndex',
-    path: '/blog'
-    template: 'dynamic'
+      waitOn: -> [
+        Meteor.subscribe 'singlePostById', Session.get('postId')
+        Meteor.subscribe 'authors'
+        Meteor.subscribe 'postTags'
+      ]
 
-    onRun: ->
-      if not Session.get('postLimit') and Blog.settings.pageSize
-        Session.set 'postLimit', Blog.settings.pageSize
+      data: ->
+        true
 
-    waitOn: ->
-      if (typeof Session isnt 'undefined')
-        [
-          subs.subscribe 'posts', Session.get('postLimit')
-          subs.subscribe 'authors'
-        ]
 
-    fastRender: true
+    #
+    # Show Blog
+    #
+    @route 'blogShow',
+      path: '/blog/:slug'
+      template: 'dynamic'
+      notFoundTemplate: 'blogNotFound'
 
-    data: ->
-      posts: Post.where {},
-        sort: publishedAt: -1
+      onRun: ->
+        Session.set('slug', @params.slug)
 
-  #
-  # Blog Tag
-  #
+      onBeforeAction: ->
+        if Blog.settings.blogNotFoundTemplate
+          @notFoundTemplate = Blog.settings.blogNotFoundTemplate
 
-  @route 'blogTagged',
-    path: '/blog/tag/:tag'
-    template: 'dynamic'
+        if Blog.settings.blogShowTemplate
+          tpl = Blog.settings.blogShowTemplate
 
-    waitOn: -> [
-      subs.subscribe 'taggedPosts', @params.tag
-      subs.subscribe 'authors'
-    ]
+          # If the user has a custom template, and not using the helper, then
+          # maintain the package Javascript.
+          pkgFunc = Template.blogShowBody.rendered
+          userFunc = Template[tpl].rendered
 
-    fastRender: true
+          if userFunc
+            Template[tpl].rendered = ->
+              pkgFunc.call(@)
+              userFunc.call(@)
+          else
+            Template[tpl].rendered = pkgFunc
 
-    data: ->
-      posts: Post.where
-        tags: @params.tag
-      ,
-        sort: publishedAt: -1
+      action: ->
+        @render() if @ready()
 
-  #
-  # Show Blog
-  #
+      waitOn: -> [
+        subs.subscribe 'singlePostBySlug', @params.slug
+        subs.subscribe 'commentsBySlug', @params.slug
+        subs.subscribe 'authors'
+      ]
 
-  @route 'blogShow',
-    path: '/blog/:slug'
-    template: 'dynamic'
-    notFoundTemplate: 'blogNotFound'
-
-    onRun: ->
-      Session.set('slug', @params.slug)
-
-    onBeforeAction: ->
-      if Blog.settings.blogNotFoundTemplate
-        @notFoundTemplate = Blog.settings.blogNotFoundTemplate
-
-      if Blog.settings.blogShowTemplate
-        tpl = Blog.settings.blogShowTemplate
-
-        # If the user has a custom template, and not using the helper, then
-        # maintain the package Javascript.
-        pkgFunc = Template.blogShowBody.rendered
-        userFunc = Template[tpl].rendered
-
-        if userFunc
-          Template[tpl].rendered = ->
-            pkgFunc.call(@)
-            userFunc.call(@)
-        else
-          Template[tpl].rendered = pkgFunc
-
-    action: ->
-      @render() if @ready()
-
-    waitOn: -> [
-      Meteor.subscribe 'singlePostBySlug', @params.slug
-      subs.subscribe 'commentsBySlug', @params.slug
-      subs.subscribe 'authors'
-    ]
-
-    data: ->
-      Post.first slug: @params.slug
-
-  #
-  # Blog Admin Index
-  #
-
-  @route 'blogAdmin',
-    path: '/admin/blog'
-    template: 'dynamic'
-
-    onBeforeAction: (pause) ->
-      if Meteor.loggingIn()
-        return pause()
-
-      Deps.autorun () ->
-        Router.go 'blogIndex' if not Meteor.userId()
-
-      Meteor.call 'isBlogAuthorized', (err, authorized) =>
-        if not authorized
-          return @redirect('/blog')
-
-    waitOn: ->
-      [ Meteor.subscribe 'postForAdmin'
-        Meteor.subscribe 'authors' ]
-
-    data: ->
-      true
-
-  #
-  # New/Edit Blog
-  #
-
-  @route 'blogAdminEdit',
-    path: '/admin/blog/edit/:id'
-    template: 'dynamic'
-
-    onBeforeAction: (pause) ->
-      if Meteor.loggingIn()
-        return pause()
-
-      Deps.autorun () ->
-        Router.go 'blogIndex' if not Meteor.userId()
-        
-      Meteor.call 'isBlogAuthorized', @params.id, (err, authorized) =>
-        if not authorized
-          return @redirect('/blog')
-
-    action: ->
-      @render() if @ready()
-
-    onRun: ->
-      Session.set 'postId', @params.id
-
-    waitOn: -> [
-      Meteor.subscribe 'singlePostById', @params.id
-      Meteor.subscribe 'authors'
-      Meteor.subscribe 'postTags'
-    ]
-
-    data: ->
-      true
+      data: ->
+        Post.first slug: @params.slug

--- a/server/boot.coffee
+++ b/server/boot.coffee
@@ -13,9 +13,20 @@ Blog =
       description: ''
 
   config: (appConfig) ->
-    @settings = _.extend(@settings, appConfig)
+    for func in @configs
+      func( appConfig )
 
-@Blog = Blog
+  configs: [ (appConfig) ->
+      @settings = _.extend(@settings, appConfig)
+  ]
+
+  extend: (extended) ->
+    extended.settings = _.extend(extended.settings, @settings)
+    extended.settings.rss = _.extend(extended.settings.rss, @settings.rss)
+    extended.configs = extended.configs.concat( @configs )
+    return extended
+
+@Blog = if @Blog then @Blog.extend( Blog ) else Blog
 
 ################################################################################
 # Bootstrap Code

--- a/versions.json
+++ b/versions.json
@@ -98,7 +98,7 @@
     ],
     [
       "iron:router",
-      "0.9.4"
+      "0.9.3"
     ],
     [
       "joshowens:shareit",


### PR DESCRIPTION
Moved config to lib to be accessible by fast-render.
Moved routes definition into startup function so that
the config definiton is defined before it runs.
To set a custom admin route set "Blog.settings.blogAdminRoute".
Moved admin routes before "blog/:_id" show route to avoid
conflict.
