### PR TITLE
Store images on Amazon S3 (CollectionFS)

### DIFF
--- a/client/views/admin/editor.coffee
+++ b/client/views/admin/editor.coffee
@@ -1,7 +1,6 @@
 class @BlogEditor extends MediumEditor
 
   # FACTORY
- 
   @make: (tpl) ->
     # Set up the medium editor with image upload
     editor = new BlogEditor '.editable',
@@ -18,28 +17,45 @@ class @BlogEditor extends MediumEditor
       addons:
         images:
           uploadFile: ($placeholder, file, that) ->
-            id = Files.insert
-              _id: Random.id()
-              contentType: 'image/jpeg'
+            # Use CollectionFS + Amazon S3
+            if Meteor.settings?.public?.blog?.useS3
+              FS.Utility.eachFile event, (file) ->
+                S3Files.insert file, (err, fileObj) ->
+                  Tracker.autorun (c) ->
+                    theFile = S3Files.find({_id: fileObj._id}).fetch()[0]
+                    if theFile.isUploaded() and theFile.url?()
+                      that.uploadCompleted { responseText: theFile.url() }, $placeholder
+                      c.stop()
+                      return
+                    else
+                      $progress = $('.progress:first', this.$el)
+                      complete = theFile.uploadProgress() ? 0
+                      $progress.attr 'value', complete
+                      $progress.html complete
+            # Use Local Filestore
+            else
+              id = FilesLocal.insert
+                _id: Random.id()
+                contentType: 'image/jpeg'
 
-            $.ajax
-              type: "post"
-              url: "/fs/#{id}"
-              xhr: ->
-                xhr = new XMLHttpRequest()
-                xhr.upload.onprogress = that.updateProgressBar
-                xhr
+              $.ajax
+                type: "post"
+                url: "/fs/#{id}"
+                xhr: ->
+                  xhr = new XMLHttpRequest()
+                  xhr.upload.onprogress = that.updateProgressBar
+                  xhr
 
-              cache: false
-              contentType: false
-              complete: (jqxhr) ->
-                that.uploadCompleted { responseText: "/fs/#{id}" }, $placeholder
-                return
+                cache: false
+                contentType: false
+                complete: (jqxhr) ->
+                  that.uploadCompleted { responseText: "/fs/#{id}" }, $placeholder
+                  return
 
-              processData: false
-              data: that.options.formatData(file)
+                processData: false
+                data: that.options.formatData(file)
 
-        #embeds: {}
+        embeds: {}
 
     editor
 

--- a/package.js
+++ b/package.js
@@ -93,7 +93,10 @@ Package.onUse(function(api) {
     'vsivsi:file-collection@0.3.3',
     'alanning:roles@1.2.13',
     'meteorhacks:fast-render@2.0.2',
-    'meteorhacks:subs-manager@1.2.0'
+    'meteorhacks:subs-manager@1.2.0',
+    'cfs:standard-packages',
+    'cfs:filesystem',
+    'cfs:s3'
   ], both);
 
   // FILES FOR SERVER AND CLIENT

--- a/versions.json
+++ b/versions.json
@@ -45,6 +45,74 @@
       "1.0.1"
     ],
     [
+      "cfs:access-point",
+      "0.0.0"
+    ],
+    [
+      "cfs:base-package",
+      "0.0.0"
+    ],
+    [
+      "cfs:collection",
+      "0.0.0"
+    ],
+    [
+      "cfs:collection-filters",
+      "0.0.0"
+    ],
+    [
+      "cfs:data-man",
+      "0.0.0"
+    ],
+    [
+      "cfs:file",
+      "0.0.0"
+    ],
+    [
+      "cfs:http-methods",
+      "0.0.24"
+    ],
+    [
+      "cfs:http-publish",
+      "0.0.0"
+    ],
+    [
+      "cfs:power-queue",
+      "0.0.1"
+    ],
+    [
+      "cfs:reactive-list",
+      "0.0.0"
+    ],
+    [
+      "cfs:reactive-property",
+      "0.0.0"
+    ],
+    [
+      "cfs:s3",
+      "0.0.1"
+    ],
+    [
+      "cfs:standard-packages",
+      "0.0.2"
+    ],
+    [
+      "cfs:storage-adapter",
+      "0.0.0"
+    ],
+    [
+      "cfs:tempstore",
+      "0.0.2"
+    ],
+    [
+      "cfs:upload-http",
+      "0.0.2"
+    ],
+    [
+      "cfs:worker",
+      "0.0.0"
+    ],
+    [
       "check",
       "1.0.2"
     ],
@@ -87,6 +155,10 @@
     [
       "htmljs",
       "1.0.2"
+    ],
+    [
+      "http",
+      "1.0.8"
     ],
     [
       "id-map",
@@ -181,6 +253,10 @@
       "1.0.9"
     ],
     [
+      "mongo-livedata",
+      "1.0.6"
+    ],
+    [
       "mrt:moment",
       "2.8.1"
     ],
@@ -195,6 +271,10 @@
     [
       "ordered-dict",
       "1.0.1"
+    ],
+    [
+      "raix:eventemitter",
+      "0.0.1"
     ],
     [
       "random",
@@ -251,6 +331,10 @@
     [
       "underscore",
       "1.0.1"
+    ],
+    [
+      "url",
+      "1.0.2"
     ],
     [
       "vsivsi:file-collection",


### PR DESCRIPTION
**Adds the ability to use CollectionFS + S3 to store your post images.**

 - Medium-insert, drag-and-drop, and progress bar will use S3 if enabled
 - Uses `Meteor.settings` instead of `Blog.config` for options because
   the code that sets up S3 loads before configuration using `Blog.config()`  has finished running.

**To setup S3 for file storage, add the following in `/settings.json` (or any other location of your choice):**

```json
 {
   "public": {
     "blog": {
       "useS3": true
     }
   },
   "private": {
     "blog": {
       "s3Config": {
         "bucket": "you-bucket-name",
         "ACL": "public-read",
         "MaxTries": 2,
         "accessKeyId": "XXXXXXXXXXXXX",
         "secretAccessKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
       }
     }
   }
 }
 ```
 **Then, Run meteor with `meteor --settings=/settings.json`**

**Note:** At this point we have configs in 3 different places (server, client, settings.json). Instead, we should probably use just `Meteor.settings` for all the config since it's guaranteed to be available by the time your app loads, and it would be secure.