### PR TITLE
Bugfixes and Improvements on the Editor

### DIFF
--- a/client/compatibility/medium-editor-insert-plugin.all.js
+++ b/client/compatibility/medium-editor-insert-plugin.all.js
@@ -388,6 +388,10 @@
       var that = this,
           $el = $.fn.mediumInsert.insert.$el;
 
+      if ( $el.data('events-bound') ) {
+        return;
+      }
+
       $el.on('selectstart mousedown', '.mediumInsert', function (e) {
         if ($(e.target).is('img') === false) {
           e.preventDefault();
@@ -495,6 +499,8 @@
 
         $(this).parents('.mediumInsert').mouseleave();
       });
+
+      $el.data('events-bound', true);
     }
 
   };
@@ -973,6 +979,10 @@
     setImageEvents: function () {
       var that = this;
 
+      if ( this.$el.data('events-bound-images') ) {
+        return;
+      }
+
       this.$el.on('mouseenter', '.mediumInsert-images', function () {
         var $img = $('img', this),
             positionTop,
@@ -1105,6 +1115,7 @@
             $(this).val(e.originalEvent.clipboardData.getData('text/plain'));
           }
         });
+        this.$el.data('events-bound-image', true);
     },
 
     /**
@@ -1118,6 +1129,10 @@
           dropSuccessful = false,
           dropSort = false,
           dropSortIndex, dropSortParent;
+
+      if ( this.$el.data('events-bound-dragdrop') ) {
+        return;
+      }
 
       $(document).on('dragover', 'body', function () {
         if ($.fn.mediumInsert.settings.enabled === false) {
@@ -1247,6 +1262,7 @@
           dropSuccessful = true;
         }
       });
+      this.$el.data('events-bound-dragdrop', true);
     }
   });
 }(jQuery));

--- a/client/compatibility/medium-editor-insert-plugin.all.js
+++ b/client/compatibility/medium-editor-insert-plugin.all.js
@@ -1452,7 +1452,7 @@
       return;
      }
      this._setImageEvents();
-     this.$el.data('events-bound-images');
+     this.$el.data('events-bound-images', true);
    },
    _setDragAndDropEvents: $.fn.mediumInsert.getAddon("images").setDragAndDropEvents,
    setDragAndDropEvents: function() {

--- a/client/compatibility/medium-editor-insert-plugin.all.js
+++ b/client/compatibility/medium-editor-insert-plugin.all.js
@@ -1,8 +1,8 @@
-/*! 
- * medium-editor-insert-plugin v0.2.13 - jQuery insert plugin for MediumEditor
+/*!
+ * medium-editor-insert-plugin v0.3.2 - jQuery insert plugin for MediumEditor
  *
  * https://github.com/orthes/medium-editor-insert-plugin
- * 
+ *
  * Copyright (c) 2014 Pavel Linkesch (http://linkesch.sk)
  * Released under the MIT license
  */
@@ -84,7 +84,8 @@
           this.elements[i].removeAttribute('contentEditable');
         }
 
-        $.fn.mediumInsert.insert.$el.mediumInsert('disable');
+        if ($.fn.mediumInsert.insert.$el)
+          $.fn.mediumInsert.insert.$el.mediumInsert('disable');
       };
 
       /**
@@ -109,7 +110,8 @@
         }
         this.bindSelect();
 
-        $.fn.mediumInsert.insert.$el.mediumInsert('enable');
+        if ($.fn.mediumInsert.insert.$el)
+          $.fn.mediumInsert.insert.$el.mediumInsert('enable');
       };
   }
 
@@ -145,9 +147,11 @@
         $.fn.mediumInsert.insert.init($(this));
 
         $.each($.fn.mediumInsert.settings.addons, function (i) {
-          var addonOptions = $.fn.mediumInsert.settings.addons[i];
-          addonOptions.$el = $.fn.mediumInsert.insert.$el;
-          addons[i].init(addonOptions);
+          if (typeof addons[i] !== 'undefined') {
+            var addonOptions = $.fn.mediumInsert.settings.addons[i];
+            addonOptions.$el = $.fn.mediumInsert.insert.$el;
+            addons[i].init(addonOptions);
+          }
         });
       });
     }
@@ -280,7 +284,11 @@
 
       if (typeof addon === 'undefined') {
         $.each($.fn.mediumInsert.settings.addons, function (i) {
-          buttons += '<li>' + addons[i].insertButton(buttonLabels) + '</li>';
+          if (typeof addons[i] === 'undefined') {
+            console.log('Addon "' + i + '" is not available. Did you forgot to include the related file?');
+          } else {
+            buttons += '<li>' + addons[i].insertButton(buttonLabels) + '</li>';
+          }
         });
       } else {
         buttons += '<li>' + addons[addon].insertButton(buttonLabels) + '</li>';
@@ -300,8 +308,6 @@
     setPlaceholders: function () {
       var that = this,
           $el = $.fn.mediumInsert.insert.$el,
-          editor = $.fn.mediumInsert.settings.editor,
-          buttonLabels = (editor && editor.options) ? editor.options.buttonLabels : '',
           insertBlock = this.getButtons(),
           $firstEl;
 
@@ -335,9 +341,15 @@
 
         // Fix not deleting placeholder in Firefox
         // by removing all empty placeholders
-        if (this.isFirefox){
+        if (that.isFirefox){
           $('.mediumInsert .mediumInsert-placeholder:empty', $el).each(function () {
-            $(this).parent().remove();
+            var parent = $(this).parent();
+
+            // if the parent has at least one div child it means it can be a plugin, so we don't remove it
+            // for example, embed works like that (Fix #98)
+            if (0 === parent.find('.mediumInsert-buttons div').length) {
+              parent.remove();
+            }
           });
         }
 
@@ -404,17 +416,19 @@
             //wrap content text in p to avoid firefox problems
             $el.contents().each((function() {
               return function(index, field) {
-                if (field.nodeName === '#text') {
+                if (field.nodeName === '#text' && field.textContent.trim() !== '') {
                   document.execCommand('insertHTML', false, "<p>" + field.data + "</p>");
                   return field.remove();
                 }
               };
             })(this));
-            //Firefox add extra br tag inside p tag
-            var latestPTag = $el.find('p').last();
-            if (latestPTag.text().length > 0) {
-              latestPTag.find('br').remove();
-            }
+            // Removed because of #94 issue
+            //
+            // Firefox add extra br tag inside p tag
+            // var latestPTag = $el.find('p').last();
+            // if (latestPTag.text().length > 0) {
+            //   latestPTag.find('br').remove();
+            // }
           }
         }
       });
@@ -681,7 +695,7 @@
     * Images default options
     */
 
-    default: {
+    defaults: {
       /**
       * Active or inactive image's drag and drop
       */
@@ -696,6 +710,11 @@
       * Relative path to a script that handles file deleting
       */
       imagesDeleteScript: 'delete.php',
+
+      /**
+      * Placeeholder text for inserting link
+      */
+      urlPlaceholder: 'Paste or type a link',
 
       /**
       * Format data before sending them to server while uploading an image
@@ -766,7 +785,7 @@
       if (options && options.$el) {
         this.$el = options.$el;
       }
-      this.options = $.extend(this.default, options);
+      this.options = $.extend(this.defaults, options);
 
       this.setImageEvents();
 
@@ -788,13 +807,13 @@
 
     insertButton: function(buttonLabels){
       var label = 'Img';
-      if (buttonLabels == 'fontawesome' || typeof buttonLabels === 'object' && !!(buttonLabels.fontawesome)) {
+      if (buttonLabels === 'fontawesome' || typeof buttonLabels === 'object' && !!(buttonLabels.fontawesome)) {
         label = '<i class="fa fa-picture-o"></i>';
       }
 
-	  if (typeof buttonLabels === 'object' && buttonLabels.img) {
-		  label = buttonLabels.img;
-	  }
+      if (typeof buttonLabels === 'object' && buttonLabels.img) {
+        label = buttonLabels.img;
+      }
 
       return '<button data-addon="images" data-action="add" class="medium-editor-action mediumInsert-action">'+label+'</button>';
     },
@@ -808,9 +827,11 @@
     preparePreviousImages: function () {
       this.$el.find('.mediumInsert-images').each(function() {
         var $parent = $(this).parent();
-        $parent.html($.fn.mediumInsert.insert.getButtons('images') +
-          '<div class="mediumInsert-placeholder" draggable="true">' + $parent.html() + '</div>'
-        );
+        if (!$parent.hasClass('mediumInsert-placeholder')) {
+          $parent.html($.fn.mediumInsert.insert.getButtons('images') +
+            '<div class="mediumInsert-placeholder" draggable="true">' + $parent.html() + '</div>'
+          );
+        }
       });
     },
 
@@ -962,12 +983,22 @@
         }
 
         if ($img.length > 0) {
-          $(this).append('<a class="mediumInsert-imageRemove"></a>');
+          $(this).append('<a class="mediumInsert-imageIcon mediumInsert-imageRemove"></a>');
 
-          if ($(this).parent().parent().hasClass('small')) {
-            $(this).append('<a class="mediumInsert-imageResizeBigger"></a>');
-          } else {
-            $(this).append('<a class="mediumInsert-imageResizeSmaller"></a>');
+          if ($(this).prevAll().length === 0) {
+            if ($(this).parent().parent().hasClass('small')) {
+              $(this).append('<a class="mediumInsert-imageIcon mediumInsert-imageResizeBigger"></a>');
+            } else {
+              $(this).append('<a class="mediumInsert-imageIcon mediumInsert-imageResizeSmaller"></a>');
+            }
+          }
+
+          if ($(this).siblings().length === 0) {
+            if ($img.parent().is('a')) {
+              $(this).append('<a class="mediumInsert-imageIcon mediumInsert-imageUnlink"></a>');
+            } else {
+              $(this).append('<a class="mediumInsert-imageIcon mediumInsert-imageLink"></a>');
+            }
           }
 
           positionTop = $img.position().top + parseInt($img.css('margin-top'), 10);
@@ -982,11 +1013,16 @@
             'top': positionTop,
             'left': positionLeft-31
           });
+          $('.mediumInsert-imageLink, .mediumInsert-imageUnlink', this).css({
+            'right': 'auto',
+            'top': positionTop,
+            'left': positionLeft-62
+          });
         }
       });
 
       this.$el.on('mouseleave', '.mediumInsert-images', function () {
-        $('.mediumInsert-imageRemove, .mediumInsert-imageResizeSmaller, .mediumInsert-imageResizeBigger', this).remove();
+        $('.mediumInsert-imageIcon', this).remove();
       });
 
       this.$el.on('click', '.mediumInsert-imageResizeSmaller', function () {
@@ -994,7 +1030,7 @@
         $(this).parent().mouseleave().mouseleave();
 
         $.fn.mediumInsert.insert.deselect();
-        that.$el.closest('[data-medium-element]').trigger('keyup').trigger('input');
+        that.$el.trigger('keyup').trigger('input');
       });
 
       this.$el.on('click', '.mediumInsert-imageResizeBigger', function () {
@@ -1002,7 +1038,7 @@
         $(this).parent().mouseleave().mouseleave();
 
         $.fn.mediumInsert.insert.deselect();
-        that.$el.closest('[data-medium-element]').trigger('keyup').trigger('input');
+        that.$el.trigger('keyup').trigger('input');
       });
 
       this.$el.on('click', '.mediumInsert-imageRemove', function () {
@@ -1016,8 +1052,59 @@
         that.deleteFile(img, that);
 
         $.fn.mediumInsert.insert.deselect();
-        that.$el.closest('[data-medium-element]').trigger('keyup').trigger('input');
+
+        that.$el.trigger('keyup').trigger('input');
       });
+
+      this.$el.on('click', '.mediumInsert-imageLink', function () {
+        var $placeholder = $(this).closest('.mediumInsert-placeholder'),
+            $formHtml = $('<div class="medium-editor-toolbar medium-editor-toolbar-active medium-editor-toolbar-form-anchor mediumInsert-imageLinkWire" style="display: block;"><input type="text" value="" placeholder="' + that.options.urlPlaceholder + '" class="mediumInsert-imageLinkText medium-editor-toolbar-anchor-input"></div>');
+
+        $formHtml.appendTo($placeholder);
+        setTimeout(function () {
+          $formHtml.find('input').focus();
+        }, 50);
+
+        $.fn.mediumInsert.insert.deselect();
+      });
+
+      this.$el.on('click', '.mediumInsert-imageUnlink', function () {
+        var $figure = $(this).closest('.mediumInsert-images');
+
+        $figure.find('img').unwrap();
+
+        $(this).removeClass('mediumInsert-imageUnlink')
+          .addClass('mediumInsert-imageLink');
+
+        that.$el.trigger('keyup').trigger('input');
+      });
+
+      this.$el
+        .on('keypress', '.mediumInsert-imageLinkText', function (e) {
+          var $placeholder = $(this).closest('.mediumInsert-placeholder');
+
+          if ((e.which && e.which === 13) || (e.keyCode && e.keyCode === 13)) {
+            $placeholder.find('.mediumInsert-images:first').find('img').wrap('<a href="'+ $(this).val() +'" target="_blank"></a>');
+            $placeholder.find('.mediumInsert-imageLink')
+              .removeClass('mediumInsert-imageLink')
+              .addClass('mediumInsert-imageUnlink');
+
+            // Workaround for "Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?"
+            try {
+              $('.mediumInsert-imageLinkWire').remove();
+            } catch(err) {}
+
+            that.$el.trigger('keyup').trigger('input');
+          }
+        })
+        .on('blur', '.mediumInsert-imageLinkText', function () {
+          $('.mediumInsert-imageLinkWire').remove();
+        })
+        .on('paste', '.mediumInsert-imageLinkText', function (e) {
+          if ($.fn.mediumInsert.insert.isFirefox && e.originalEvent.clipboardData) {
+            $(this).val(e.originalEvent.clipboardData.getData('text/plain'));
+          }
+        });
     },
 
     /**
@@ -1089,7 +1176,7 @@
           dropSuccessful = false;
           dropSort = false;
 
-          that.$el.closest('[data-medium-element]').trigger('keyup').trigger('input');
+          that.$el.trigger('keyup').trigger('input');
         }
       });
 
@@ -1131,7 +1218,7 @@
         dropSort = true;
         dropSortIndex = null;
 
-        that.$el.closest('[data-medium-element]').trigger('keyup').trigger('input');
+        that.$el.trigger('keyup').trigger('input');
       });
 
       this.$el.on('drop', '.mediumInsert', function (e) {

--- a/client/compatibility/medium-editor-insert-plugin.all.js
+++ b/client/compatibility/medium-editor-insert-plugin.all.js
@@ -388,10 +388,6 @@
       var that = this,
           $el = $.fn.mediumInsert.insert.$el;
 
-      if ( $el.data('events-bound') ) {
-        return;
-      }
-
       $el.on('selectstart mousedown', '.mediumInsert', function (e) {
         if ($(e.target).is('img') === false) {
           e.preventDefault();
@@ -499,8 +495,6 @@
 
         $(this).parents('.mediumInsert').mouseleave();
       });
-
-      $el.data('events-bound', true);
     }
 
   };
@@ -979,10 +973,6 @@
     setImageEvents: function () {
       var that = this;
 
-      if ( this.$el.data('events-bound-images') ) {
-        return;
-      }
-
       this.$el.on('mouseenter', '.mediumInsert-images', function () {
         var $img = $('img', this),
             positionTop,
@@ -1115,7 +1105,6 @@
             $(this).val(e.originalEvent.clipboardData.getData('text/plain'));
           }
         });
-        this.$el.data('events-bound-image', true);
     },
 
     /**
@@ -1129,10 +1118,6 @@
           dropSuccessful = false,
           dropSort = false,
           dropSortIndex, dropSortParent;
-
-      if ( this.$el.data('events-bound-dragdrop') ) {
-        return;
-      }
 
       $(document).on('dragover', 'body', function () {
         if ($.fn.mediumInsert.settings.enabled === false) {
@@ -1262,7 +1247,6 @@
           dropSuccessful = true;
         }
       });
-      this.$el.data('events-bound-dragdrop', true);
     }
   });
 }(jQuery));

--- a/client/compatibility/medium-editor-insert-plugin.all.js
+++ b/client/compatibility/medium-editor-insert-plugin.all.js
@@ -1415,3 +1415,56 @@
   });
 
 }(jQuery));
+
+
+
+// Extend medium-insert to work with meteor-blog
+(function($) {
+/**
+ *  Namespace: $.fn.mediumInsert
+ */
+    var extensionMethods = {
+        /*
+         * skip setEvents when events have already been bound
+         */
+        init: function ($el) {
+          this.$el = $el;
+          this.isFirefox = navigator.userAgent.match(/firefox/i);
+          this.setPlaceholders();
+          if ( !this.$el.data('events-bound') ) {
+            this.setEvents();
+            this.$el.data('events-bound', true);
+          }
+        }
+    };
+
+    $.extend(true, $[ "fn" ][ "mediumInsert" ][ "insert" ], extensionMethods);
+
+/**
+*
+* Extend mediumInsert image addon
+*
+**/
+ var extendImages = {
+   _setImageEvents: $.fn.mediumInsert.getAddon("images").setImageEvents,
+   setImageEvents: function() {
+     if ( this.$el.data('events-bound-images') ) {
+      return;
+     }
+     this._setImageEvents();
+     this.$el.data('events-bound-images');
+   },
+   _setDragAndDropEvents: $.fn.mediumInsert.getAddon("images").setDragAndDropEvents,
+   setDragAndDropEvents: function() {
+     if ( this.$el.data('events-bound-dragdrop') ) {
+       return;
+     }
+     this._setDragAndDropEvents();
+     this.$el.data('events-bound-dragdrop', true);
+   }
+ }
+
+  $.extend(true, $.fn.mediumInsert.getAddon("images"), extendImages);
+
+
+})(jQuery);

--- a/client/compatibility/medium-editor.js
+++ b/client/compatibility/medium-editor.js
@@ -1,15 +1,25 @@
 // medium-editor.js
-// Version: 1.9.4
+// Version: 1.9.13
 // https://github.com/daviferreira/medium-editor
 //
 // Scoping modified so that Meteor sees this function inside a package.
+
 
 function MediumEditorClass(elements, options) {
     'use strict';
     return this.init(elements, options);
 }
-
 MediumEditor = MediumEditorClass;
+if (typeof module === 'object') {
+    module.exports = MediumEditor;
+}
+// AMD support
+else if (typeof define === 'function' && define.amd) {
+    define(function () {
+        'use strict';
+        return MediumEditor;
+    });
+}
 
 (function (window, document) {
     'use strict';
@@ -44,7 +54,7 @@ MediumEditor = MediumEditorClass;
         var i,
             len,
             ranges,
-            sel = window.getSelection();
+            sel = this.options.contentWindow.getSelection();
         if (sel.getRangeAt && sel.rangeCount) {
             ranges = [];
             for (i = 0, len = sel.rangeCount; i < len; i += 1) {
@@ -58,7 +68,7 @@ MediumEditor = MediumEditorClass;
     function restoreSelection(savedSel) {
         var i,
             len,
-            sel = window.getSelection();
+            sel = this.options.contentWindow.getSelection();
         if (savedSel) {
             sel.removeAllRanges();
             for (i = 0, len = savedSel.length; i < len; i += 1) {
@@ -70,7 +80,7 @@ MediumEditor = MediumEditorClass;
     // http://stackoverflow.com/questions/1197401/how-can-i-get-the-element-the-caret-is-in-with-javascript-when-using-contentedi
     // by You
     function getSelectionStart() {
-        var node = document.getSelection().anchorNode,
+        var node = this.options.ownerDocument.getSelection().anchorNode,
             startNode = (node && node.nodeType === 3 ? node.parentNode : node);
         return startNode;
     }
@@ -83,18 +93,18 @@ MediumEditor = MediumEditorClass;
             sel,
             len,
             container;
-        if (window.getSelection !== undefined) {
-            sel = window.getSelection();
+        if (this.options.contentWindow.getSelection !== undefined) {
+            sel = this.options.contentWindow.getSelection();
             if (sel.rangeCount) {
-                container = document.createElement('div');
+                container = this.options.ownerDocument.createElement('div');
                 for (i = 0, len = sel.rangeCount; i < len; i += 1) {
                     container.appendChild(sel.getRangeAt(i).cloneContents());
                 }
                 html = container.innerHTML;
             }
-        } else if (document.selection !== undefined) {
-            if (document.selection.type === 'Text') {
-                html = document.selection.createRange().htmlText;
+        } else if (this.options.ownerDocument.selection !== undefined) {
+            if (this.options.ownerDocument.selection.type === 'Text') {
+                html = this.options.ownerDocument.selection.createRange().htmlText;
             }
         }
         return html;
@@ -103,6 +113,39 @@ MediumEditor = MediumEditorClass;
     // https://github.com/jashkenas/underscore
     function isElement(obj) {
         return !!(obj && obj.nodeType === 1);
+    }
+
+    // http://stackoverflow.com/questions/6690752/insert-html-at-caret-in-a-contenteditable-div
+    function insertHTMLCommand(doc, html) {
+        var selection, range, el, fragment, node, lastNode;
+
+        if (doc.queryCommandSupported('insertHTML')) {
+            return doc.execCommand('insertHTML', false, html);
+        }
+
+        selection = window.getSelection();
+        if (selection.getRangeAt && selection.rangeCount) {
+            range = selection.getRangeAt(0);
+            range.deleteContents();
+
+            el = doc.createElement("div");
+            el.innerHTML = html;
+            fragment = doc.createDocumentFragment();
+            while (el.firstChild) {
+                node = el.firstChild;
+                lastNode = fragment.appendChild(node);
+            }
+            range.insertNode(fragment);
+
+            // Preserve the selection:
+            if (lastNode) {
+                range = range.cloneRange();
+                range.setStartAfter(lastNode);
+                range.collapse(true);
+                selection.removeAllRanges();
+                selection.addRange(range);
+            }
+        }
     }
 
     MediumEditor.prototype = {
@@ -122,6 +165,8 @@ MediumEditor = MediumEditorClass;
             disableToolbar: false,
             disableEditing: false,
             elementsContainer: false,
+            contentWindow: window,
+            ownerDocument: document,
             firstHeader: 'h3',
             forcePlainText: true,
             placeholder: 'Type your text',
@@ -141,24 +186,51 @@ MediumEditor = MediumEditorClass;
         isIE: ((navigator.appName === 'Microsoft Internet Explorer') || ((navigator.appName === 'Netscape') && (new RegExp('Trident/.*rv:([0-9]{1,}[.0-9]{0,})').exec(navigator.userAgent) !== null))),
 
         init: function (elements, options) {
+            this.options = extend(options, this.defaults);
             this.setElementSelection(elements);
             if (this.elements.length === 0) {
                 return;
             }
             this.parentElements = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'];
-            this.id = document.querySelectorAll('.medium-editor-toolbar').length + 1;
-            this.options = extend(options, this.defaults);
+            if (!this.options.elementsContainer) {
+                this.options.elementsContainer = document.body;
+            }
+            this.id = this.options.elementsContainer.querySelectorAll('.medium-editor-toolbar').length + 1;
             return this.setup();
         },
 
         setup: function () {
+            this.events = [];
             this.isActive = true;
             this.initElements()
                 .bindSelect()
                 .bindPaste()
                 .setPlaceholders()
+                .bindElementActions()
                 .bindWindowActions()
                 .passInstance();
+        },
+
+        on: function(target, event, listener, useCapture) {
+            target.addEventListener(event, listener, useCapture);
+            this.events.push([target, event, listener, useCapture]);
+        },
+
+        off: function(target, event, listener, useCapture) {
+            var index = this.events.indexOf([target, event, listener, useCapture]),
+                e;
+            if(index !== -1) {
+                e = this.events.splice(index, 1);
+                e[0].removeEventListener(e[1], e[2], e[3]);
+            }
+        },
+
+        removeAllEvents: function() {
+            var e = this.events.pop();
+            while(e) {
+                e[0].removeEventListener(e[1], e[2], e[3]);
+                e = this.events.pop();
+            }
         },
 
         initElements: function () {
@@ -173,16 +245,13 @@ MediumEditor = MediumEditorClass;
                     this.elements[i].setAttribute('data-placeholder', this.options.placeholder);
                 }
                 this.elements[i].setAttribute('data-medium-element', true);
-                this.bindParagraphCreation(i).bindReturn(i).bindTab(i);
+                this.bindParagraphCreation(i);
                 if (!this.options.disableToolbar && !this.elements[i].getAttribute('data-disable-toolbar')) {
                     addToolbar = true;
                 }
             }
             // Init toolbar
             if (addToolbar) {
-                if (!this.options.elementsContainer) {
-                    this.options.elementsContainer = document.body;
-                }
                 this.initToolbar()
                     .bindButtons()
                     .bindAnchorForm()
@@ -197,9 +266,105 @@ MediumEditor = MediumEditorClass;
         },
 
         updateElementList: function () {
-            this.elements = typeof this.elementSelection === 'string' ? document.querySelectorAll(this.elementSelection) : this.elementSelection;
+            this.elements = typeof this.elementSelection === 'string' ? this.options.ownerDocument.querySelectorAll(this.elementSelection) : this.elementSelection;
             if (this.elements.nodeType === 1) {
                 this.elements = [this.elements];
+            }
+        },
+
+        bindBlur: function(i) {
+            var self = this,
+                blurFunction = function(e){
+                    // If it's not part of the editor, or the toolbar
+                    if ( e.target !== self.toolbar
+                        && e.target !== self.elements[0]
+                        && !isDescendant(self.elements[0], e.target)
+                        && !isDescendant(self.toolbar, e.target)
+                        && !isDescendant(self.anchorPreview, e.target)) {
+
+                        // Activate the placeholder
+                        self.placeholderWrapper(self.elements[0], e);
+
+                        // Hide the toolbar after a small delay so we can prevent this on toolbar click
+                        setTimeout(function(){
+                            if ( !self.keepToolbarAlive ) {
+                                self.hideToolbarActions();
+                            }
+                        }, 200);
+                    }
+                };
+
+            // Hide the toolbar when focusing outside of the editor.
+            document.body.addEventListener('click', blurFunction, true);
+            document.body.addEventListener('focus', blurFunction, true);
+
+            return this;
+        },
+
+        bindKeypress: function(i) {
+            var self = this;
+
+            // Set up the keypress events
+            this.elements[i].addEventListener('keypress', function(event){
+                self.placeholderWrapper(this,event);
+            });
+
+            return this;
+        },
+
+        bindClick: function(i) {
+            var self = this;
+
+            this.elements[i].addEventListener('click', function(){
+                // Remove placeholder
+                this.classList.remove('medium-editor-placeholder');
+
+                if ( self.options.staticToolbar ) {
+                    self.setToolbarPosition();
+                }
+            });
+
+            return this;
+        },
+
+        /**
+         * This handles blur and keypress events on elements
+         * Including Placeholders, and tooldbar hiding on blur
+         */
+        bindElementActions: function() {
+            var i;
+
+            for (i = 0; i < this.elements.length; i += 1) {
+
+                // Active all of the placeholders
+                this.activatePlaceholder(this.elements[i]);
+
+                // Bind the return and tab keypress events
+                this.bindReturn(i)
+                    .bindTab(i)
+                    .bindBlur(i)
+                    .bindClick(i)
+                    .bindKeypress(i);
+
+            }
+
+            return this;
+        },
+
+        // Two functions to handle placeholders
+        activatePlaceholder:  function (el) {
+
+            if (!(el.querySelector('img')) &&
+                    !(el.querySelector('blockquote')) &&
+                    el.textContent.replace(/^\s+|\s+$/g, '') === '') {
+
+                el.classList.add('medium-editor-placeholder');
+            }
+        },
+        placeholderWrapper: function (el, e) {
+            el.classList.remove('medium-editor-placeholder');
+            if (e.type !== 'keypress') {
+                this.activatePlaceholder(el);
             }
         },
 
@@ -267,8 +432,8 @@ MediumEditor = MediumEditorClass;
 
         bindParagraphCreation: function (index) {
             var self = this;
-            this.elements[index].addEventListener('keypress', function (e) {
-                var node = getSelectionStart(),
+            this.on(this.elements[index], 'keypress', function (e) {
+                var node = getSelectionStart.call(self),
                     tagName;
                 if (e.which === 32) {
                     tagName = node.tagName.toLowerCase();
@@ -278,16 +443,20 @@ MediumEditor = MediumEditorClass;
                 }
             });
 
-            this.elements[index].addEventListener('keyup', function (e) {
-                var node = getSelectionStart(),
-                    tagName;
+            this.on(this.elements[index], 'keyup', function (e) {
+                var node = getSelectionStart.call(self),
+                    tagName,
+                    editorElement;
+
                 if (node && node.getAttribute('data-medium-element') && node.children.length === 0 && !(self.options.disableReturn || node.getAttribute('data-disable-return'))) {
                     document.execCommand('formatBlock', false, 'p');
                 }
                 if (e.which === 13) {
-                    node = getSelectionStart();
+                    node = getSelectionStart.call(self);
                     tagName = node.tagName.toLowerCase();
-                    if (!(self.options.disableReturn || this.getAttribute('data-disable-return')) &&
+                    editorElement = self.getSelectionElement();
+
+                    if (!(self.options.disableReturn || editorElement.getAttribute('data-disable-return')) &&
                         tagName !== 'li' && !self.isListItemChild(node)) {
                         if (!e.shiftKey) {
                             document.execCommand('formatBlock', false, 'p');
@@ -320,13 +489,13 @@ MediumEditor = MediumEditorClass;
 
         bindReturn: function (index) {
             var self = this;
-            this.elements[index].addEventListener('keypress', function (e) {
+            this.on(this.elements[index], 'keypress', function (e) {
                 if (e.which === 13) {
                     if (self.options.disableReturn || this.getAttribute('data-disable-return')) {
                         e.preventDefault();
                     } else if (self.options.disableDoubleReturn || this.getAttribute('data-disable-double-return')) {
-                        var node = getSelectionStart();
-                        if (node && node.innerText === '\n') {
+                        var node = getSelectionStart.call(self);
+                        if (node && node.textContent === '\n') {
                             e.preventDefault();
                         }
                     }
@@ -336,10 +505,11 @@ MediumEditor = MediumEditorClass;
         },
 
         bindTab: function (index) {
-            this.elements[index].addEventListener('keydown', function (e) {
+            var self = this;
+            this.on(this.elements[index], 'keydown', function (e) {
                 if (e.which === 9) {
                     // Override tab only for pre nodes
-                    var tag = getSelectionStart().tagName.toLowerCase();
+                    var tag = getSelectionStart.call(self).tagName.toLowerCase();
                     if (tag === 'pre') {
                         e.preventDefault();
                         document.execCommand('insertHtml', null, '    ');
@@ -367,7 +537,7 @@ MediumEditor = MediumEditorClass;
                     'bold': '<button class="medium-editor-action medium-editor-action-bold" data-action="bold" data-element="b">' + buttonLabels.bold + '</button>',
                     'italic': '<button class="medium-editor-action medium-editor-action-italic" data-action="italic" data-element="i">' + buttonLabels.italic + '</button>',
                     'underline': '<button class="medium-editor-action medium-editor-action-underline" data-action="underline" data-element="u">' + buttonLabels.underline + '</button>',
-                    'strikethrough': '<button class="medium-editor-action medium-editor-action-strikethrough" data-action="strikethrough" data-element="strike"><strike>A</strike></button>',
+                    'strikethrough': '<button class="medium-editor-action medium-editor-action-strikethrough" data-action="strikethrough" data-element="strike">' + buttonLabels.strikethrough +'</button>',
                     'superscript': '<button class="medium-editor-action medium-editor-action-superscript" data-action="superscript" data-element="sup">' + buttonLabels.superscript + '</button>',
                     'subscript': '<button class="medium-editor-action medium-editor-action-subscript" data-action="subscript" data-element="sub">' + buttonLabels.subscript + '</button>',
                     'anchor': '<button class="medium-editor-action medium-editor-action-anchor" data-action="anchor" data-element="a">' + buttonLabels.anchor + '</button>',
@@ -379,7 +549,11 @@ MediumEditor = MediumEditorClass;
                     'unorderedlist': '<button class="medium-editor-action medium-editor-action-unorderedlist" data-action="insertunorderedlist" data-element="ul">' + buttonLabels.unorderedlist + '</button>',
                     'pre': '<button class="medium-editor-action medium-editor-action-pre" data-action="append-pre" data-element="pre">' + buttonLabels.pre + '</button>',
                     'indent': '<button class="medium-editor-action medium-editor-action-indent" data-action="indent" data-element="ul">' + buttonLabels.indent + '</button>',
-                    'outdent': '<button class="medium-editor-action medium-editor-action-outdent" data-action="outdent" data-element="ul">' + buttonLabels.outdent + '</button>'
+                    'outdent': '<button class="medium-editor-action medium-editor-action-outdent" data-action="outdent" data-element="ul">' + buttonLabels.outdent + '</button>',
+                    'justifyCenter': '<button class="medium-editor-action medium-editor-action-justifyCenter" data-action="justifyCenter" data-element="">' + buttonLabels.justifyCenter + '</button>',
+                    'justifyFull': '<button class="medium-editor-action medium-editor-action-justifyFull" data-action="justifyFull" data-element="">' + buttonLabels.justifyFull + '</button>',
+                    'justifyLeft': '<button class="medium-editor-action medium-editor-action-justifyLeft" data-action="justifyLeft" data-element="">' + buttonLabels.justifyLeft + '</button>',
+                    'justifyRight': '<button class="medium-editor-action medium-editor-action-justifyRight" data-action="justifyRight" data-element="">' + buttonLabels.justifyRight + '</button>'
                 };
             return buttonTemplates[btnType] || false;
         },
@@ -392,6 +566,7 @@ MediumEditor = MediumEditorClass;
                     'bold': '<b>B</b>',
                     'italic': '<b><i>I</i></b>',
                     'underline': '<b><u>U</u></b>',
+                    'strikethrough': '<s>A</s>',
                     'superscript': '<b>x<sup>1</sup></b>',
                     'subscript': '<b>x<sub>1</sub></b>',
                     'anchor': '<b>#</b>',
@@ -403,13 +578,18 @@ MediumEditor = MediumEditorClass;
                     'unorderedlist': '<b>&bull;</b>',
                     'pre': '<b>0101</b>',
                     'indent': '<b>&rarr;</b>',
-                    'outdent': '<b>&larr;</b>'
+                    'outdent': '<b>&larr;</b>',
+                    'justifyCenter': '<b>C</b>',
+                    'justifyFull': '<b>J</b>',
+                    'justifyLeft': '<b>L</b>',
+                    'justifyRight': '<b>R</b>'
                 };
             if (buttonLabelType === 'fontawesome') {
                 customButtonLabels = {
                     'bold': '<i class="fa fa-bold"></i>',
                     'italic': '<i class="fa fa-italic"></i>',
                     'underline': '<i class="fa fa-underline"></i>',
+                    'strikethrough': '<i class="fa fa-strikethrough"></i>',
                     'superscript': '<i class="fa fa-superscript"></i>',
                     'subscript': '<i class="fa fa-subscript"></i>',
                     'anchor': '<i class="fa fa-link"></i>',
@@ -419,7 +599,11 @@ MediumEditor = MediumEditorClass;
                     'unorderedlist': '<i class="fa fa-list-ul"></i>',
                     'pre': '<i class="fa fa-code fa-lg"></i>',
                     'indent': '<i class="fa fa-indent"></i>',
-                    'outdent': '<i class="fa fa-outdent"></i>'
+                    'outdent': '<i class="fa fa-outdent"></i>',
+                    'justifyCenter': '<i class="fa fa-align-center"></i>',
+                    'justifyFull': '<i class="fa fa-align-justify"></i>',
+                    'justifyLeft': '<i class="fa fa-align-left"></i>',
+                    'justifyRight': '<i class="fa fa-align-right"></i>'
                 };
             } else if (typeof buttonLabelType === 'object') {
                 customButtonLabels = buttonLabelType;
@@ -454,6 +638,13 @@ MediumEditor = MediumEditorClass;
             var toolbar = document.createElement('div');
             toolbar.id = 'medium-editor-toolbar-' + this.id;
             toolbar.className = 'medium-editor-toolbar';
+
+            if ( this.options.staticToolbar ) {
+                toolbar.className += " static-toolbar";
+            } else {
+                toolbar.className += " stalker-toolbar";
+            }
+
             toolbar.appendChild(this.toolbarButtons());
             toolbar.appendChild(this.toolbarFormAnchor());
             this.options.elementsContainer.appendChild(toolbar);
@@ -564,11 +755,12 @@ MediumEditor = MediumEditorClass;
                 }, self.options.delay);
             };
 
-            document.documentElement.addEventListener('mouseup', this.checkSelectionWrapper);
+            this.on(document.documentElement, 'mouseup', this.checkSelectionWrapper);
 
             for (i = 0; i < this.elements.length; i += 1) {
-                this.elements[i].addEventListener('keyup', this.checkSelectionWrapper);
-                this.elements[i].addEventListener('blur', this.checkSelectionWrapper);
+                this.on(this.elements[i], 'keyup', this.checkSelectionWrapper);
+                this.on(this.elements[i], 'blur', this.checkSelectionWrapper);
+                this.elements[i].addEventListener('click', this.checkSelectionWrapper);
             }
             return this;
         },
@@ -579,15 +771,24 @@ MediumEditor = MediumEditorClass;
 
             if (this.keepToolbarAlive !== true && !this.options.disableToolbar) {
 
-                newSelection = window.getSelection();
+                newSelection = this.options.contentWindow.getSelection();
                 if (newSelection.toString().trim() === '' ||
                     (this.options.allowMultiParagraphSelection === false && this.hasMultiParagraphs()) ||
                     this.selectionInContentEditableFalse()) {
-                    this.hideToolbarActions();
+
+                    if ( !this.options.staticToolbar ) {
+                        this.hideToolbarActions();
+                    } else if (this.anchorForm.style.display === 'block') {
+                        this.setToolbarButtonStates();
+                        this.showToolbarActions();
+                    }
+
                 } else {
                     selectionElement = this.getSelectionElement();
                     if (!selectionElement || selectionElement.getAttribute('data-disable-toolbar')) {
-                        this.hideToolbarActions();
+                        if ( !this.options.staticToolbar ) {
+                            this.hideToolbarActions();
+                        }
                     } else {
                         this.checkSelectionElement(newSelection, selectionElement);
                     }
@@ -607,7 +808,7 @@ MediumEditor = MediumEditorClass;
         },
 
         hasMultiParagraphs: function () {
-            var selectionHtml = getSelectionHtml().replace(/<[\S]+><\/[\S]+>/gim, ''),
+            var selectionHtml = getSelectionHtml.call(this).replace(/<[\S]+><\/[\S]+>/gim, ''),
                 hasMultiParagraphs = selectionHtml.match(/<(p|h[0-6]|blockquote)>([\s\S]*?)<\/(p|h[0-6]|blockquote)>/g);
 
             return (hasMultiParagraphs ? hasMultiParagraphs.length : 0);
@@ -625,40 +826,38 @@ MediumEditor = MediumEditorClass;
                     return;
                 }
             }
-            this.hideToolbarActions();
+
+            if ( !this.options.staticToolbar ) {
+                this.hideToolbarActions();
+            }
         },
 
         findMatchingSelectionParent: function(testElementFunction) {
-            var selection = window.getSelection(),
-                range, current, parent,
-                result,
-                getElement = function (e) {
-                    var localParent = e;
-                    try {
-                        while (!testElementFunction(localParent)) {
-                            localParent = localParent.parentNode;
-                        }
-                    } catch (errb) {
-                        return false;
-                    }
-                    return localParent;
-                };
-            // First try on current node
-            try {
-                range = selection.getRangeAt(0);
-                current = range.commonAncestorContainer;
-                parent = current.parentNode;
+            var selection = this.options.contentWindow.getSelection(), range, current;
 
-                if (testElementFunction(current)) {
-                    result = current;
-                } else {
-                    result = getElement(parent);
-                }
-                // If not search in the parent nodes.
-            } catch (err) {
-                result = getElement(parent);
+            if (selection.rangeCount === 0) {
+                return false;
             }
-            return result;
+
+            range = selection.getRangeAt(0);
+            current = range.commonAncestorContainer;
+
+            do {
+              if (current.nodeType === 1){
+                if ( testElementFunction(current) )
+                {
+                    return current;
+                }
+                // do not traverse upwards past the nearest containing editor
+                if (current.getAttribute('data-medium-element')) {
+                    return false;
+                }
+              }
+
+              current = current.parentNode;
+            } while (current);
+
+            return false;
         },
 
         getSelectionElement: function () {
@@ -674,28 +873,71 @@ MediumEditor = MediumEditorClass;
         },
 
         setToolbarPosition: function () {
-            var buttonHeight = 50,
-                selection = window.getSelection(),
-                range = selection.getRangeAt(0),
-                boundary = range.getBoundingClientRect(),
-                defaultLeft = (this.options.diffLeft) - (this.toolbar.offsetWidth / 2),
-                middleBoundary = (boundary.left + boundary.right) / 2,
-                halfOffsetWidth = this.toolbar.offsetWidth / 2;
-            if (boundary.top < buttonHeight) {
-                this.toolbar.classList.add('medium-toolbar-arrow-over');
-                this.toolbar.classList.remove('medium-toolbar-arrow-under');
-                this.toolbar.style.top = buttonHeight + boundary.bottom - this.options.diffTop + window.pageYOffset - this.toolbar.offsetHeight + 'px';
-            } else {
-                this.toolbar.classList.add('medium-toolbar-arrow-under');
-                this.toolbar.classList.remove('medium-toolbar-arrow-over');
-                this.toolbar.style.top = boundary.top + this.options.diffTop + window.pageYOffset - this.toolbar.offsetHeight + 'px';
+            // document.documentElement for IE 9
+            var scrollTop = (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop,
+            container = this.elements[0],
+            containerRect = container.getBoundingClientRect(),
+            containerTop = containerRect.top + scrollTop,
+            buttonHeight = 50,
+            selection = window.getSelection(),
+            range,
+            boundary,
+            middleBoundary,
+            defaultLeft = (this.options.diffLeft) - (this.toolbar.offsetWidth / 2),
+            halfOffsetWidth = this.toolbar.offsetWidth / 2;
+
+            if ( selection.focusNode === null ) {
+                return this;
             }
-            if (middleBoundary < halfOffsetWidth) {
-                this.toolbar.style.left = defaultLeft + halfOffsetWidth + 'px';
-            } else if ((window.innerWidth - middleBoundary) < halfOffsetWidth) {
-                this.toolbar.style.left = window.innerWidth + defaultLeft - halfOffsetWidth + 'px';
+
+            this.toolbar.classList.add('medium-editor-toolbar-active');
+
+            if ( this.options.staticToolbar ) {
+
+                if ( this.options.stickyToolbar ) {
+
+                    // If it's beyond the height of the editor, position it at the bottom of the editor
+                    if ( scrollTop > (containerTop + this.elements[0].offsetHeight - this.toolbar.offsetHeight)) {
+                        this.toolbar.style.top = (containerTop + this.elements[0].offsetHeight) + 'px';
+                    }
+                    // Stick the toolbar to the top of the window
+                    else if ( scrollTop > (containerTop - this.toolbar.offsetHeight) ) {
+                        this.toolbar.classList.add('sticky-toolbar');
+                        this.toolbar.style.top = "0px";
+                    }
+                    // Normal static toolbar position
+                    else {
+                        this.toolbar.classList.remove('sticky-toolbar');
+                        this.toolbar.style.top = containerTop - this.toolbar.offsetHeight + "px";
+                    }
+
+                } else {
+                    this.toolbar.style.top = containerTop - this.toolbar.offsetHeight + "px";
+                }
+
+                this.toolbar.style.left = containerRect.left + "px";
+
             } else {
-                this.toolbar.style.left = defaultLeft + middleBoundary + 'px';
+                range = selection.getRangeAt(0);
+                boundary = range.getBoundingClientRect();
+                middleBoundary = (boundary.left + boundary.right) / 2;
+
+                if (boundary.top < buttonHeight) {
+                    this.toolbar.classList.add('medium-toolbar-arrow-over');
+                    this.toolbar.classList.remove('medium-toolbar-arrow-under');
+                    this.toolbar.style.top = buttonHeight + boundary.bottom - this.options.diffTop + this.options.contentWindow.pageYOffset - this.toolbar.offsetHeight + 'px';
+                } else {
+                    this.toolbar.classList.add('medium-toolbar-arrow-under');
+                    this.toolbar.classList.remove('medium-toolbar-arrow-over');
+                    this.toolbar.style.top = boundary.top + this.options.diffTop + this.options.contentWindow.pageYOffset - this.toolbar.offsetHeight + 'px';
+                }
+                if (middleBoundary < halfOffsetWidth) {
+                    this.toolbar.style.left = defaultLeft + halfOffsetWidth + 'px';
+                } else if ((this.options.contentWindow.innerWidth - middleBoundary) < halfOffsetWidth) {
+                    this.toolbar.style.left = this.options.contentWindow.innerWidth + defaultLeft - halfOffsetWidth + 'px';
+                } else {
+                    this.toolbar.style.left = defaultLeft + middleBoundary + 'px';
+                }
             }
 
             this.hideAnchorPreview();
@@ -755,7 +997,7 @@ MediumEditor = MediumEditorClass;
                     }
                 };
             for (i = 0; i < buttons.length; i += 1) {
-                buttons[i].addEventListener('click', triggerAction);
+                this.on(buttons[i], 'click', triggerAction);
             }
             this.setFirstAndLastItems(buttons);
             return this;
@@ -777,9 +1019,9 @@ MediumEditor = MediumEditorClass;
             } else if (action === 'anchor') {
                 this.triggerAnchorAction(e);
             } else if (action === 'image') {
-                document.execCommand('insertImage', false, window.getSelection());
+                this.options.ownerDocument.execCommand('insertImage', false, this.options.contentWindow.getSelection());
             } else {
-                document.execCommand(action, false, null);
+                this.options.ownerDocument.execCommand(action, false, null);
                 this.setToolbarPosition();
             }
         },
@@ -809,7 +1051,7 @@ MediumEditor = MediumEditorClass;
             var selectedParentElement = this.getSelectedParentElement();
             if (selectedParentElement.tagName &&
                     selectedParentElement.tagName.toLowerCase() === 'a') {
-                document.execCommand('unlink', false, null);
+                this.options.ownerDocument.execCommand('unlink', false, null);
             } else {
                 if (this.anchorForm.style.display === 'block') {
                     this.showToolbarActions();
@@ -827,7 +1069,7 @@ MediumEditor = MediumEditorClass;
             // https://developer.mozilla.org/en-US/docs/Rich-Text_Editing_in_Mozilla
             if (el === 'blockquote' && selectionData.el &&
                 selectionData.el.parentNode.tagName.toLowerCase() === 'blockquote') {
-                return document.execCommand('outdent', false, null);
+                return this.options.ownerDocument.execCommand('outdent', false, null);
             }
             if (selectionData.tagName === el) {
                 el = 'p';
@@ -838,11 +1080,11 @@ MediumEditor = MediumEditorClass;
             // http://stackoverflow.com/questions/1816223/rich-text-editor-with-blockquote-function/1821777#1821777
             if (this.isIE) {
                 if (el === 'blockquote') {
-                    return document.execCommand('indent', false, el);
+                    return this.options.ownerDocument.execCommand('indent', false, el);
                 }
                 el = '<' + el + '>';
             }
-            return document.execCommand('formatBlock', false, el);
+            return this.options.ownerDocument.execCommand('formatBlock', false, el);
         },
 
         getSelectionData: function (el) {
@@ -895,11 +1137,11 @@ MediumEditor = MediumEditorClass;
         },
 
         saveSelection: function() {
-            this.savedSelection = saveSelection();
+            this.savedSelection = saveSelection.call(this);
         },
 
         restoreSelection: function() {
-            restoreSelection(this.savedSelection);
+            restoreSelection.call(this, this.savedSelection);
         },
 
         showAnchorForm: function (link_value) {
@@ -917,12 +1159,12 @@ MediumEditor = MediumEditorClass;
                 linkSave = this.anchorForm.querySelector('a.medium-editor-toobar-anchor-save'),
                 self = this;
 
-            this.anchorForm.addEventListener('click', function (e) {
+            this.on(this.anchorForm, 'click', function (e) {
                 e.stopPropagation();
                 self.keepToolbarAlive = true;
             });
 
-            this.anchorInput.addEventListener('keyup', function (e) {
+            this.on(this.anchorInput, 'keyup', function (e) {
                 var button = null,
                     target;
 
@@ -943,7 +1185,7 @@ MediumEditor = MediumEditorClass;
                 }
             });
 
-            linkSave.addEventListener('click', function(e) {
+            this.on(linkSave, 'click', function(e) {
                 var button = null,
                     target;
                 e.preventDefault();
@@ -961,30 +1203,30 @@ MediumEditor = MediumEditorClass;
                 self.createLink(self.anchorInput, target, button);
             }, true);
 
-            this.anchorInput.addEventListener('click', function (e) {
+            this.on(this.anchorInput, 'click', function (e) {
                 // make sure not to hide form when cliking into the input
                 e.stopPropagation();
                 self.keepToolbarAlive = true;
             });
 
             // Hide the anchor form when focusing outside of it.
-            document.body.addEventListener('click', function (e) {
+            this.on(this.options.ownerDocument.body, 'click', function (e) {
                 if (e.target !== self.anchorForm && !isDescendant(self.anchorForm, e.target) && !isDescendant(self.toolbarActions, e.target)) {
                     self.keepToolbarAlive = false;
                     self.checkSelection();
                 }
             }, true);
-            document.body.addEventListener('focus', function (e) {
+            this.on(this.options.ownerDocument.body, 'focus', function (e) {
                 if (e.target !== self.anchorForm && !isDescendant(self.anchorForm, e.target) && !isDescendant(self.toolbarActions, e.target)) {
                     self.keepToolbarAlive = false;
                     self.checkSelection();
                 }
             }, true);
 
-            linkCancel.addEventListener('click', function (e) {
+            this.on(linkCancel, 'click', function (e) {
                 e.preventDefault();
                 self.showToolbarActions();
-                restoreSelection(self.savedSelection);
+                restoreSelection.call(self, self.savedSelection);
             });
             return this;
         },
@@ -1024,11 +1266,11 @@ MediumEditor = MediumEditorClass;
 
             self.anchorPreview.classList.add('medium-toolbar-arrow-over');
             self.anchorPreview.classList.remove('medium-toolbar-arrow-under');
-            self.anchorPreview.style.top = Math.round(buttonHeight + boundary.bottom - self.options.diffTop + window.pageYOffset - self.anchorPreview.offsetHeight) + 'px';
+            self.anchorPreview.style.top = Math.round(buttonHeight + boundary.bottom - self.options.diffTop + this.options.contentWindow.pageYOffset - self.anchorPreview.offsetHeight) + 'px';
             if (middleBoundary < halfOffsetWidth) {
                 self.anchorPreview.style.left = defaultLeft + halfOffsetWidth + 'px';
-            } else if ((window.innerWidth - middleBoundary) < halfOffsetWidth) {
-                self.anchorPreview.style.left = window.innerWidth + defaultLeft - halfOffsetWidth + 'px';
+            } else if ((this.options.contentWindow.innerWidth - middleBoundary) < halfOffsetWidth) {
+                self.anchorPreview.style.left = this.options.contentWindow.innerWidth + defaultLeft - halfOffsetWidth + 'px';
             } else {
                 self.anchorPreview.style.left = defaultLeft + middleBoundary + 'px';
             }
@@ -1061,30 +1303,30 @@ MediumEditor = MediumEditorClass;
 
                         // cleanup
                         clearInterval(interval_timer);
-                        self.anchorPreview.removeEventListener('mouseover', stamp);
-                        self.anchorPreview.removeEventListener('mouseout', unstamp);
-                        anchorEl.removeEventListener('mouseover', stamp);
-                        anchorEl.removeEventListener('mouseout', unstamp);
+                        self.off(self.anchorPreview, 'mouseover', stamp);
+                        self.off(self.anchorPreview, 'mouseout', unstamp);
+                        self.off(anchorEl, 'mouseover', stamp);
+                        self.off(anchorEl, 'mouseout', unstamp);
 
                     }
                 }, 200);
 
-            self.anchorPreview.addEventListener('mouseover', stamp);
-            self.anchorPreview.addEventListener('mouseout', unstamp);
-            anchorEl.addEventListener('mouseover', stamp);
-            anchorEl.addEventListener('mouseout', unstamp);
+            this.on(self.anchorPreview, 'mouseover', stamp);
+            this.on(self.anchorPreview, 'mouseout', unstamp);
+            this.on(anchorEl, 'mouseover', stamp);
+            this.on(anchorEl, 'mouseout', unstamp);
         },
 
         createAnchorPreview: function () {
             var self = this,
-                anchorPreview = document.createElement('div');
+                anchorPreview = this.options.ownerDocument.createElement('div');
 
             anchorPreview.id = 'medium-editor-anchor-preview-' + this.id;
             anchorPreview.className = 'medium-editor-anchor-preview';
             anchorPreview.innerHTML = this.anchorPreviewTemplate();
             this.options.elementsContainer.appendChild(anchorPreview);
 
-            anchorPreview.addEventListener('click', function () {
+            this.on(anchorPreview, 'click', function () {
                 self.anchorPreviewClickHandler();
             });
 
@@ -1101,8 +1343,8 @@ MediumEditor = MediumEditorClass;
             if (this.activeAnchor) {
 
                 var self = this,
-                    range = document.createRange(),
-                    sel = window.getSelection();
+                    range = this.options.ownerDocument.createRange(),
+                    sel = this.options.contentWindow.getSelection();
 
                 range.selectNodeContents(self.activeAnchor);
                 sel.removeAllRanges();
@@ -1125,7 +1367,7 @@ MediumEditor = MediumEditorClass;
                 leaveAnchor = function () {
                     // mark the anchor as no longer hovered, and stop listening
                     overAnchor = false;
-                    self.activeAnchor.removeEventListener('mouseout', leaveAnchor);
+                    self.off(self.activeAnchor, 'mouseout', leaveAnchor);
                 };
 
             if (e.target && e.target.tagName.toLowerCase() === 'a') {
@@ -1143,7 +1385,7 @@ MediumEditor = MediumEditorClass;
                     return true;
                 }
                 this.activeAnchor = e.target;
-                this.activeAnchor.addEventListener('mouseout', leaveAnchor);
+                this.on(this.activeAnchor, 'mouseout', leaveAnchor);
                 // show the anchor preview according to the configured delay
                 // if the mouse has not left the anchor tag in that time
                 setTimeout(function () {
@@ -1162,7 +1404,7 @@ MediumEditor = MediumEditorClass;
                 self.editorAnchorObserver(e);
             };
             for (i = 0; i < this.elements.length; i += 1) {
-                this.elements[i].addEventListener('mouseover', this.editorAnchorObserverWrapper);
+                this.on(this.elements[i], 'mouseover', this.editorAnchorObserverWrapper);
             }
             return this;
         },
@@ -1172,13 +1414,14 @@ MediumEditor = MediumEditorClass;
             return (re.test(value) ? '' : 'http://') + value;
         },
 
-        setTargetBlank: function () {
-            var el = getSelectionStart(),
-                i;
+        setTargetBlank: function (el) {
+            var i;
+            el = el || getSelectionStart.call(this);
             if (el.tagName.toLowerCase() === 'a') {
                 el.target = '_blank';
             } else {
                 el = el.getElementsByTagName('a');
+
                 for (i = 0; i < el.length; i += 1) {
                     el[i].target = '_blank';
                 }
@@ -1186,7 +1429,7 @@ MediumEditor = MediumEditorClass;
         },
 
         setButtonClass: function (buttonClass) {
-            var el = getSelectionStart(),
+            var el = getSelectionStart.call(this),
                 classes = buttonClass.split(' '),
                 i, j;
             if (el.tagName.toLowerCase() === 'a') {
@@ -1211,13 +1454,13 @@ MediumEditor = MediumEditorClass;
                 return;
             }
 
-            restoreSelection(this.savedSelection);
+            restoreSelection.call(this, this.savedSelection);
 
             if (this.options.checkLinkFormat) {
                 input.value = this.checkLinkFormat(input.value);
             }
 
-            document.execCommand('createLink', false, input.value);
+            this.options.ownerDocument.execCommand('createLink', false, input.value);
 
             if (this.options.targetBlank || target === "_blank") {
                 this.setTargetBlank();
@@ -1228,8 +1471,8 @@ MediumEditor = MediumEditorClass;
             }
 
             if (this.options.targetBlank || target === "_blank" || buttonClass) {
-                event = document.createEvent("HTMLEvents");
-                event.initEvent("input", true, true, window);
+                event = this.options.ownerDocument.createEvent("HTMLEvents");
+                event.initEvent("input", true, true, this.options.contentWindow);
                 for (i = 0; i < this.elements.length; i += 1) {
                     this.elements[i].dispatchEvent(event);
                 }
@@ -1251,7 +1494,19 @@ MediumEditor = MediumEditorClass;
                     }
                 }, 100);
             };
-            window.addEventListener('resize', this.windowResizeHandler);
+
+            // Add a scroll event for sticky toolbar
+            if ( this.options.staticToolbar && this.options.stickyToolbar ) {
+
+                // On scroll, re-position the toolbar
+                window.addEventListener('scroll', function() {
+                    if (self.toolbar && self.toolbar.classList.contains('medium-editor-toolbar-active')) {
+                        self.setToolbarPosition();
+                    }
+                }, true);
+            }
+
+            this.on(this.options.contentWindow, 'resize', this.windowResizeHandler);
             return this;
         },
 
@@ -1278,18 +1533,12 @@ MediumEditor = MediumEditorClass;
                 delete this.anchorPreview;
             }
 
-            document.documentElement.removeEventListener('mouseup', this.checkSelectionWrapper);
-            window.removeEventListener('resize', this.windowResizeHandler);
-
             for (i = 0; i < this.elements.length; i += 1) {
-                this.elements[i].removeEventListener('mouseover', this.editorAnchorObserverWrapper);
-                this.elements[i].removeEventListener('keyup', this.checkSelectionWrapper);
-                this.elements[i].removeEventListener('blur', this.checkSelectionWrapper);
-                this.elements[i].removeEventListener('paste', this.pasteWrapper);
                 this.elements[i].removeAttribute('contentEditable');
                 this.elements[i].removeAttribute('data-medium-element');
             }
 
+            this.removeAllEvents();
         },
 
         htmlEntities: function (str) {
@@ -1303,21 +1552,34 @@ MediumEditor = MediumEditorClass;
             this.pasteWrapper = function (e) {
                 var paragraphs,
                     html = '',
-                    p;
+                    p,
+                    dataFormatHTML = 'text/html',
+                    dataFormatPlain = 'text/plain';
 
                 this.classList.remove('medium-editor-placeholder');
                 if (!self.options.forcePlainText && !self.options.cleanPastedHTML) {
                     return this;
                 }
 
+                if (window.clipboardData && e.clipboardData === undefined) {
+                    e.clipboardData = window.clipboardData;
+                    // If window.clipboardData exists, but e.clipboardData doesn't exist,
+                    // we're probably in IE. IE only has two possibilities for clipboard
+                    // data format: 'Text' and 'URL'.
+                    //
+                    // Of the two, we want 'Text':
+                    dataFormatHTML = 'Text';
+                    dataFormatPlain = 'Text';
+                }
+
                 if (e.clipboardData && e.clipboardData.getData && !e.defaultPrevented) {
                     e.preventDefault();
 
-                    if (self.options.cleanPastedHTML && e.clipboardData.getData('text/html')) {
-                        return self.cleanPaste(e.clipboardData.getData('text/html'));
+                    if (self.options.cleanPastedHTML && e.clipboardData.getData(dataFormatHTML)) {
+                        return self.cleanPaste(e.clipboardData.getData(dataFormatHTML));
                     }
                     if (!(self.options.disableReturn || this.getAttribute('data-disable-return'))) {
-                        paragraphs = e.clipboardData.getData('text/plain').split(/[\r\n]/g);
+                        paragraphs = e.clipboardData.getData(dataFormatPlain).split(/[\r\n]/g);
                         for (p = 0; p < paragraphs.length; p += 1) {
                             if (paragraphs[p] !== '') {
                                 if (navigator.userAgent.match(/firefox/i) && p === 0) {
@@ -1327,14 +1589,15 @@ MediumEditor = MediumEditorClass;
                                 }
                             }
                         }
-                        document.execCommand('insertHTML', false, html);
+                        insertHTMLCommand(self.options.ownerDocument, html);
                     } else {
-                        document.execCommand('insertHTML', false, e.clipboardData.getData('text/plain'));
+                        html = self.htmlEntities(e.clipboardData.getData(dataFormatPlain));
+                        insertHTMLCommand(self.options.ownerDocument, html);
                     }
                 }
             };
             for (i = 0; i < this.elements.length; i += 1) {
-                this.elements[i].addEventListener('paste', this.pasteWrapper);
+                this.on(this.elements[i], 'paste', this.pasteWrapper);
             }
             return this;
         },
@@ -1356,8 +1619,8 @@ MediumEditor = MediumEditorClass;
                 };
             for (i = 0; i < this.elements.length; i += 1) {
                 activatePlaceholder(this.elements[i]);
-                this.elements[i].addEventListener('blur', placeholderWrapper);
-                this.elements[i].addEventListener('keypress', placeholderWrapper);
+                this.on(this.elements[i], 'blur', placeholderWrapper);
+                this.on(this.elements[i], 'keypress', placeholderWrapper);
             }
             return this;
         },
@@ -1412,15 +1675,20 @@ MediumEditor = MediumEditorClass;
                 elList = text.split('<br><br>');
 
                 this.pasteHTML('<p>' + elList.join('</p><p>') + '</p>');
-                document.execCommand('insertText', false, "\n");
+                this.options.ownerDocument.execCommand('insertText', false, "\n");
 
                 // block element cleanup
-                elList = el.querySelectorAll('p,div,br');
+                elList = el.querySelectorAll('a,p,div,br');
                 for (i = 0; i < elList.length; i += 1) {
 
                     workEl = elList[i];
 
                     switch (workEl.tagName.toLowerCase()) {
+                    case 'a':
+                        if (this.options.targetBlank){
+                          this.setTargetBlank(workEl);
+                        }
+                        break;
                     case 'p':
                     case 'div':
                         this.filterCommonBlocks(workEl);
@@ -1442,9 +1710,9 @@ MediumEditor = MediumEditorClass;
         },
 
         pasteHTML: function (html) {
-            var elList, workEl, i, fragmentBody, pasteBlock = document.createDocumentFragment();
+            var elList, workEl, i, fragmentBody, pasteBlock = this.options.ownerDocument.createDocumentFragment();
 
-            pasteBlock.appendChild(document.createElement('body'));
+            pasteBlock.appendChild(this.options.ownerDocument.createElement('body'));
 
             fragmentBody = pasteBlock.querySelector('body');
             fragmentBody.innerHTML = html;
@@ -1466,13 +1734,13 @@ MediumEditor = MediumEditorClass;
                 }
 
             }
-            document.execCommand('insertHTML', false, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));
+            this.options.ownerDocument.execCommand('insertHTML', false, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));
         },
         isCommonBlock: function (el) {
             return (el && (el.tagName.toLowerCase() === 'p' || el.tagName.toLowerCase() === 'div'));
         },
         filterCommonBlocks: function (el) {
-            if (/^\s*$/.test(el.innerText)) {
+            if (/^\s*$/.test(el.textContent)) {
                 el.parentNode.removeChild(el);
             }
         },
@@ -1517,7 +1785,7 @@ MediumEditor = MediumEditorClass;
             for (i = 0; i < spans.length; i += 1) {
 
                 el = spans[i];
-                new_el = document.createElement(el.classList.contains('bold') ? 'b' : 'i');
+                new_el = this.options.ownerDocument.createElement(el.classList.contains('bold') ? 'b' : 'i');
 
                 if (el.classList.contains('bold') && el.classList.contains('italic')) {
 
@@ -1542,7 +1810,7 @@ MediumEditor = MediumEditorClass;
                 if (/^\s*$/.test()) {
                     el.parentNode.removeChild(el);
                 } else {
-                    el.parentNode.replaceChild(document.createTextNode(el.innerText), el);
+                    el.parentNode.replaceChild(this.options.ownerDocument.createTextNode(el.textContent), el);
                 }
 
             }

--- a/client/stylesheets/lib/medium-editor.css
+++ b/client/stylesheets/lib/medium-editor.css
@@ -58,21 +58,6 @@
             transform: matrix(1, 0, 0, 1, 0, 0);
     opacity: 1; } }
 
-.btn {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  background: #efefef;
-  border: 1px solid #ccc;
-  white-space: nowrap;
-  padding: 6px 12px;
-  border-radius: 4px;
-  color: #333;
-  text-decoration: none; }
-  .btn:hover {
-    text-decoration: underline; }
 
 .medium-toolbar-arrow-under:after, .medium-toolbar-arrow-over:before {
   position: absolute;

--- a/client/views/admin/edit.coffee
+++ b/client/views/admin/edit.coffee
@@ -100,22 +100,22 @@ Template.blogAdminEdit.rendered = ->
         @$('.editable').html post.body
         @$('.html-editor').html post.body
 
-  # Tags
-  $tags = @$('[data-role=tagsinput]')
-  $tags.tagsinput confirmKeys: [13, 44, 9]
-  $tags.tagsinput('input').typeahead(
-    highlight: true,
-    hint: false
-  ,
-    name: 'tags'
-    displayKey: 'val'
-    source: substringMatcher Tag.first().tags
-  ).bind 'typeahead:selected', (obj, datum) ->
-    $tags.tagsinput 'add', datum.val
-    $tags.tagsinput('input').typeahead 'val', ''
+      # Tags
+      $tags = @$('[data-role=tagsinput]')
+      $tags.tagsinput confirmKeys: [13, 44, 9]
+      $tags.tagsinput('input').typeahead(
+        highlight: true,
+        hint: false
+      ,
+        name: 'tags'
+        displayKey: 'val'
+        source: substringMatcher Tag.first().tags
+      ).bind 'typeahead:selected', (obj, datum) ->
+        $tags.tagsinput 'add', datum.val
+        $tags.tagsinput('input').typeahead 'val', ''
 
-  # Medium editor
-  BlogEditor.make @
+      # Medium editor
+      BlogEditor.make @
 
 Template.blogAdminEdit.helpers
   post: ->

--- a/client/views/admin/editor.coffee
+++ b/client/views/admin/editor.coffee
@@ -49,9 +49,8 @@ class @BlogEditor extends MediumEditor
     @init.apply @, arguments
 
     # Don't let the medium insert plugin submit the form
-    $(@elements[0]).find('.mediumInsert-action').on 'click', (e) ->
-      e.preventDefault()
-      e.stopPropagation()
+    $('form').on 'click', (event) ->
+      if $(event.target).is '.mediumInsert' then event.preventDefault();
 
   # Return medium editor's contents
   contents: ->


### PR DESCRIPTION
_(more detailed descriptions on each commit)_

**This pull request fixes and/or improves certain behavior of meteor-blog which causes bugs or makes it prone to bugs.**

### **Fixed bugs:**
 1. images getting nested too much by medium-insert, due to it being called by `BlogEditor.make` on every autosave (example below):    
  ![screenshot bug](https://s3.amazonaws.com/f.cl.ly/items/2u0p1H35292h2H3l0L2f/Screen%20Recording%202014-12-23%20at%2011.41%20AM.gif)  
 2. medium-insert add buttons not working due to events being bound multiple times
 3. Images disappearing sometimes when switching between HTML and visual editor
 4. drag and dropping images sometimes adding the same image multiple times.
 5. Medium Editor initiates before existing post content is populated into the editor.

### Improvements:
 1. Initial call to `BlogEditor.make` moved into the `autorun` which waits for the subscription, ensuring that any existing post content is available when setting up Medium Editor.
 2. Event binding on `.mediumInsert` buttons was too broad and could cause problems. Delegated it to the form to improve reliability.
 3. Check if certain events have already bound to prevent duplicate binding
 4. Update Medium Editor to 1.9.13
 5. Update medium-editor-insert to v0.3.2

**TODO:** Rather than calling `BlogEditor.make` upon autosaving and toggling between the visual/HTML editors, we should have separate functions for each that just run the necessary parts of Medium Editor and medium insert. 