### PR TITLE
bug fix: side-comments.js not available to custom blog template

### DIFF
--- a/client/compatibility/side-comments.js
+++ b/client/compatibility/side-comments.js
@@ -42,7 +42,7 @@ function requireClass(path, parent, orig) {
   return module.exports;
 }
 
-require = requireClass
+window.require = requireClass
 
 /**
  * Registered modules.


### PR DESCRIPTION
Fixes bug caused by `require` being undefined when using a custom template for showing a blog post.