### PR TITLE
Fixes `insert: access denied` error when adding a Side Comment

### DIFF
--- a/collections/comment.coffee
+++ b/collections/comment.coffee
@@ -6,3 +6,11 @@ class @Comment extends Minimongoid
     name: 'post'
     identifier: 'postId'
   ]
+
+Comment._collection.allow
+  insert: (userId, doc) ->
+    !!userId
+  update: (userId, doc, fields, modifier) ->
+    doc.comment.authorId == userId
+  remove: (userId, doc) ->
+    doc.comment.authorId == userId


### PR DESCRIPTION
Fixed Side comments not working due to not having an `allow` set.