### PR TITLE
updated to new font-awesome via pacakge dependency

### DIFF
--- a/client/boot.coffee
+++ b/client/boot.coffee
@@ -45,12 +45,6 @@ Blog =
 
 
 Meteor.startup ->
-  # Load Font Awesome
-  $('<link>',
-    href: '//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css'
-    rel: 'stylesheet'
-  ).appendTo 'head'
-
   # Listen for any 'Load More' clicks
   $('body').on 'click', '.blog-load-more', (e) ->
     e.preventDefault()

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A package that provides a blog at /blog",
-  version: "0.6.1",
+  version: "0.6.2",
   name: "ryw:blog",
   git: "https://github.com/Differential/meteor-blog.git"
 });
@@ -93,7 +93,8 @@ Package.onUse(function(api) {
     'vsivsi:file-collection@0.3.3',
     'alanning:roles@1.2.13',
     'meteorhacks:fast-render@2.0.2',
-    'meteorhacks:subs-manager@1.2.0'
+    'meteorhacks:subs-manager@1.2.0',
+    'fortawesome:fontawesome'
   ], both);
 
   // FILES FOR SERVER AND CLIENT


### PR DESCRIPTION
I was having an issue using fontawesome 4.2 because this package uses 4.0 via a link in the head to a bootstrap cdn. I think this is a more meteoric way of doing things.