### PR TITLE
Bugfix: Editor keeps autosaving even when not typing.

### DIFF
--- a/client/views/admin/edit.coffee
+++ b/client/views/admin/edit.coffee
@@ -149,7 +149,7 @@ Template.blogAdminEdit.events
     $html.height($editable.height())
 
   # Autosave
-  'input .editable, keyup .editable, keyup .html-editor': _.debounce (e, tpl) ->
+  'input .editable, keydown .editable, keydown .html-editor': _.debounce (e, tpl) ->
     save tpl, (id, err) ->
       if err
         return Notifications.error '', err.message


### PR DESCRIPTION
 - I did some tests and found that every time the autosave runs,
  somehow it's firing a `keyup` event, which causes the autosave to run
  again and again inifinitely. I haven't figured out what's causing that,
  but for now I changed the event map to autosave on `keydown` instead of
  `keyup` which fixes the issue.