### PR TITLE
Remove whitespace before period in post excerpt

### DIFF
--- a/collections/post.coffee
+++ b/collections/post.coffee
@@ -51,7 +51,7 @@ class @Post extends Minimongoid
       ret = ''
       while not ret and matches[i]
         # Strip tags and clean up whitespaces
-        ret += matches[i++].replace(/(<([^>]+)>)/ig, ' ').replace('&nbsp;', ' ').trim()
+        ret += matches[i++].replace(/(<([^>]+)>)/ig, ' ').replace(/(\s\.)/, '.').replace('&nbsp;', ' ').trim()
       ret
 
   authorName: ->


### PR DESCRIPTION
I've noticed that when a sentence finishes with a closing HTML tag before the period the excerpt will display a whitespace before the period.

For example:
`
on a <a href="http://en.wikipedia.org/wiki/Virtual_private_server" style="line-height: 1.42857143; background-color: rgb(255, 255, 255);">virtual private server</a>.
`

will result in the excerpt:

`
on a virtual private server .
`

The code change will replace every `' .'` with `'.'`

Do you think this is a clean solution for the problem?