### PR TITLE
Update to newest version of ShareIt Package

### DIFF
--- a/.versions
+++ b/.versions
@@ -48,7 +48,7 @@ iron:location@1.0.7
 iron:middleware-stack@1.0.7
 iron:router@1.0.7
 iron:url@1.0.7
-joshowens:shareit@0.2.0
+joshowens:shareit@0.3.1
 jquery@1.11.3
 json@1.0.2
 kaptron:minimongoid@0.9.1

--- a/package.js
+++ b/package.js
@@ -19,7 +19,7 @@ Package.onUse(function(api) {
     'less',
     'underscore',
     'aslagle:reactive-table@0.5.5',
-    'joshowens:shareit@0.2.0',
+    'joshowens:shareit@0.3.1',
     'gfk:notifications@1.0.11'
   ], 'client');
 

--- a/versions.json
+++ b/versions.json
@@ -202,7 +202,7 @@
     ],
     [
       "joshowens:shareit",
-      "0.2.0"
+      "0.3.1"
     ],
     [
       "jquery",


### PR DESCRIPTION
Update to newest version ShareIt package to allow use of unique description in meta tags/social media sharing