### PR TITLE
Optionally make drafts inaccessible to public via Blog.config

### DIFF
--- a/client/boot.coffee
+++ b/client/boot.coffee
@@ -12,6 +12,7 @@ Blog =
     blogAdminTemplate: null
     blogAdminEditTemplate: null
     pageSize: 20
+    publicDrafts: true
     excerptFunction: null
     syntaxHighlighting: false
     syntaxHighlightingTheme: 'github'

--- a/router.coffee
+++ b/router.coffee
@@ -81,6 +81,9 @@ Router.route '/blog/:slug',
       else
         Template[tpl].rendered = pkgFunc
 
+    if !Blog.settings.publicDrafts and !Post.first().published
+      Meteor.call 'isBlogAuthorized', (err, authorized) =>
+        return @redirect('/blog') unless authorized
     @next()
   action: ->
     @render() if @ready()


### PR DESCRIPTION
To use, add `publicDrafts: false` to your client-side `Blog.config`.

Solves #128 and partially solves #129.