### PR TITLE
allow passing region into the cfs s3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ other location of your choice).
         "ACL": "public-read",
         "MaxTries": 2,
         "accessKeyId": "XXXXXXXXXXXXX",
-        "secretAccessKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        "secretAccessKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "region": "OPTIONAL most of the time"
       }
     }
   }

--- a/collections/files.coffee
+++ b/collections/files.coffee
@@ -60,6 +60,7 @@ if Meteor.isServer and useS3
     bucket: s3Config.bucket
     ACL:  s3Config.s3ACL
     maxTries: s3Config.s3MaxTries
+    region: s3Config.region
 
   @S3Files = new FS.Collection "s3Imports",
     stores: [s3ImportStore]


### PR DESCRIPTION
(sorry for the duplicate pr)

When you setup S3 to serve assets from a subdomain you have to name the bucket according to your subdomain. If you edit your blog config with the details, a module will throw an error:

>Error: Error storing file to the s3Imports store: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.

This can be easily fixed by providing a region (CFS has support for this).
