### PR TITLE
use maintained, up to date shareit package

### DIFF
--- a/package.js
+++ b/package.js
@@ -19,7 +19,7 @@ Package.onUse(function(api) {
     'less',
     'underscore',
     'aslagle:reactive-table@0.5.5',
-    'joshowens:shareit@0.3.1',
+    'lovetostrike:shareit@0.4.1',
     'gfk:notifications@1.0.11'
   ], 'client');
 


### PR DESCRIPTION
the shareit package in the package.js is not maintained anymore, luckily there is a maintained version with a few improvements provided by @lovetostrike at https://github.com/lovetostrike/shareit/ 

Edit: it seems the repo is actually up to date, however the published atmosphere package is not current.
https://github.com/meteorclub/shareit/issues/38
Will see if maintainer is willing to provide an updated version.