### PR TITLE
fixed shareit problem with twitter card

### DIFF
--- a/client/views/blog/blog.coffee
+++ b/client/views/blog/blog.coffee
@@ -128,6 +128,16 @@ Template.blogShowBody.events
 Template.blogShowBody.helpers
   isAdmin: () ->
     Session.get "canEditPost"
+  shareData: () ->
+    post = Post.first slug: Session.get('slug')
+
+    {
+      title: post.title,
+      excerpt: post.excerpt,
+      description: post.description,
+      author: post.authorName(),
+      thumbnail: post.thumbnail()
+    }
 
 
 Template.disqus.rendered = ->

--- a/client/views/blog/show.html
+++ b/client/views/blog/show.html
@@ -35,7 +35,7 @@
   <div class="blog-back-link pull-left">
     <a href="{{pathFor 'blogIndex'}}"><i class="fa fa-caret-left"></i>Back to the Blog</a>
   </div>
-  {{> shareit}}
+  {{> shareit shareData}}
   {{> disqus this}}
 </template>
 


### PR DESCRIPTION
**problem**
when running shareit in its default configuration it renders facebook, g+, pinterest and twitter buttons.
the twitter view sets twitter card meta tags. one of which is ```twitter:creator```. since it accesses the surrounding template's data context it directly tries to retrieve those information from the ```Post``` object.

This goes quite well for most properties except for the author, there it produces the following error (which is logged as debug since it comes from the tracker flush).

```
Error: Match error: Failed Match.OneOf or Match.Optional validation
    at checkSubtree (http://localhost:3000/packages/check.js?ac81167b8513b85b926c167bba423981b0c4cf9c:279:11)
    at check (http://localhost:3000/packages/check.js?ac81167b8513b85b926c167bba423981b0c4cf9c:67:5)
    at _.extend._getFindOptions (http://localhost:3000/packages/mongo.js?3cfe0c5981c197df33036a37574850f057e934a6:331:7)
    at _.extend.findOne (http://localhost:3000/packages/mongo.js?3cfe0c5981c197df33036a37574850f057e934a6:389:42)
    at Function.Minimongoid.Minimongoid.first (http://localhost:3000/packages/kaptron_minimongoid.js?8864bea00856c8dcb1bdd4f400053a3d0a5095ab:632:32)
    at Function.Minimongoid.Minimongoid.find (http://localhost:3000/packages/kaptron_minimongoid.js?8864bea00856c8dcb1bdd4f400053a3d0a5095ab:678:19)
    at HTMLMetaElement.<anonymous> (http://localhost:3000/packages/kaptron_minimongoid.js?8864bea00856c8dcb1bdd4f400053a3d0a5095ab:318:39)
    at jQuery.access (http://localhost:3000/packages/jquery.js?dd8bac56f8fd3666d433d2285ae01e52597cc51a:4199:63)
    at jQuery.fn.extend.attr (http://localhost:3000/packages/jquery.js?dd8bac56f8fd3666d433d2285ae01e52597cc51a:7961:10)
    at jQuery.fn.init (http://localhost:3000/packages/jquery.js?dd8bac56f8fd3666d433d2285ae01e52597cc51a:2846:14) undefined
```

the error originates from here: https://github.com/lovetostrike/shareit/blob/v0.4/client/views/twitter/twitter.coffee#L27

the reason for this failure is that the ```author``` is called as a property and not as a function which causes jquery to pass ```0``` as ```options``` which minimongoid tries to interpret as query options. since ```0``` is not a valid option the check call fails with the above stacktrace.

imho even if the ```author``` would be called as a function it would not return anything meaningful which is why I decided to implement a custom shareData helper which explicitly sets the fields and which uses ```authorName``` and its sophisticated logic to get an author name.