### PR TITLE
added mention of group settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ select users can edit the blog, the package supports two roles:
 * `adminRole` - Can create, and modify or delete any post.
 * `authorRole` - Can create, and modify or delete only my own posts.
 
+In addition, if using groups from the alanning:roles package, set the associated group using
+* `adminGroup` - Group associated with `adminRole`.
+* `authorGroup` - Group associated with `authorRole`.
+
 To enable either or both roles, specify values in the blog config:
 
 ```coffee


### PR DESCRIPTION
added mention of group settings for roles configuration using alanning:roles, fixes #205
The feature was already existing (found by studying the code) but was undocumented in the readme.