### PR TITLE
Allow tags to be saved on edit

### DIFF
--- a/client/views/admin/edit.coffee
+++ b/client/views/admin/edit.coffee
@@ -83,7 +83,7 @@ save = (tpl, cb) ->
 
   attrs =
     title: $('[name=title]', $form).val()
-    tags: getBlogTags($('[name=tags]', $form).val())
+    tags: getBlogTags($('[name=tags]', $form).val().split(','))
     slug: slug
     description: $('[name=description]', $form).val()
     body: body


### PR DESCRIPTION
A consequence of PR #241 was that tags were no longer saved at all, because getBlogTags() received tags as a string even when there were several of them, causing them to be returned as an empty array.
