### PR TITLE
Fix for already initialised FlowRouter

### DIFF
--- a/router.coffee
+++ b/router.coffee
@@ -222,5 +222,5 @@ Meteor.startup ->
 
   Blog.Router.routeAll routes
 
-  if Package['kadira:flow-router']
+  if Package['kadira:flow-router'] and not FlowRouter._initialized
     FlowRouter.initialize()


### PR DESCRIPTION
On a hard refresh I get an error saying FlowRouter is already initialised (which in my app it is). This fix only initialises if not already. I've never written coffee before, please let me know if it's wrong.